### PR TITLE
Add group member management

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -212,6 +212,9 @@
                     <span class="material-icons">arrow_back</span>
                 </button>
                 <div id="currentChatInfo" data-translate="selectChat">Selecciona un chat para comenzar</div>
+                <button id="addMembersBtn" class="icon-button hidden" title="Agregar miembros" data-translate="addMembers">
+                    <i class="fas fa-user-plus"></i>
+                </button>
             </div>
             <div id="messagesList" class="messages-list">
             <div id="typingIndicator" style="display:none; font-style: italic; padding: 5px 10px; color: #555;"></div>


### PR DESCRIPTION
## Summary
- add button in chat header to invite members to an existing group
- implement modal for searching and selecting users
- enable adding participants to group chats with translated interface

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68401cb6f88c832da77f3a922df14de2