### PR TITLE
Fix add members button visibility

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1465,7 +1465,11 @@ async function openChat(chatId) {
         console.log('Datos del chat:', chatData);
         currentChatParticipants = chatData.participants || [];
         if (addMembersBtn) {
-            addMembersBtn.style.display = chatData.type === 'group' ? 'block' : 'none';
+            if (chatData.type === 'group') {
+                addMembersBtn.classList.remove('hidden');
+            } else {
+                addMembersBtn.classList.add('hidden');
+            }
         }
 
         // Limpiar mensajes anteriores
@@ -2043,7 +2047,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 showAddMembersModal(currentChat, currentChatParticipants);
             }
         });
-        addBtn.style.display = 'none';
+        addBtn.classList.add('hidden');
     }
 });
 
@@ -2074,7 +2078,7 @@ function toggleChatList(show) {
         }
 
         if (addBtn) {
-            addBtn.style.display = 'none';
+            addBtn.classList.add('hidden');
         }
 
         // Restablecer estado del chat actual
@@ -2106,7 +2110,7 @@ function toggleChatList(show) {
     }
 
     if (addBtn && show) {
-        addBtn.style.display = 'none';
+        addBtn.classList.add('hidden');
     }
 
     adjustMobileLayout();


### PR DESCRIPTION
## Summary
- show add members button for group chats by toggling `hidden` class
- keep button hidden otherwise

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684027085dec832d9b6348231c421274