### PR TITLE
Fix unread chat colors and localStorage

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -858,22 +858,19 @@ function showDeleteConfirmDialog(chatId, chatElement) {
 // Función para cargar chats en tiempo real
 async function setupRealtimeChats(container = chatList, chatType = null) {
     console.log('🔄 Configurando escucha de chats en tiempo real');
-    
-    // Cancelar suscripción anterior si existe
+
     if (unsubscribeChats) {
-        console.log('📤 Cancelando suscripción anterior de chats');
         unsubscribeChats();
         unsubscribeChats = null;
     }
 
-    // Limpiar la lista de chats o grupos
     if (container) {
         container.innerHTML = '';
     }
 
     const currentUser = getCurrentUser();
-    const currentLang = document.getElementById('languageSelect')?.value || 
-                       document.getElementById('languageSelectMain')?.value || 
+    const currentLang = document.getElementById('languageSelect')?.value ||
+                       document.getElementById('languageSelectMain')?.value ||
                        getUserLanguage();
 
     if (!db || !currentUser) {
@@ -885,140 +882,111 @@ async function setupRealtimeChats(container = chatList, chatType = null) {
     }
 
     try {
-        console.log('🔍 Configurando consulta de chats para usuario:', currentUser.uid);
-        
-        // Set para mantener un registro de los chats ya mostrados
-        const displayedChats = new Set();
-        
-        const constraints = [
-            where('participants', 'array-contains', currentUser.uid)
-        ];
+        const constraints = [where('participants', 'array-contains', currentUser.uid)];
         if (chatType) {
             constraints.push(where('type', '==', chatType));
         }
-        constraints.push(orderBy('lastMessageTime', 'desc'));
 
         const q = query(collection(db, 'chats'), ...constraints);
 
-        // Crear nueva suscripción
         unsubscribeChats = onSnapshot(q, async (snapshot) => {
             try {
-                console.log('📥 Actualización de chats detectada');
-                
-                // Limpiar lista actual solo si no hay chats mostrados
-                if (container && displayedChats.size === 0) {
-                    container.innerHTML = '';
-                }
-                
+                if (container) container.innerHTML = '';
+
                 if (snapshot.empty) {
-                    if (container && displayedChats.size === 0) {
+                    if (container) {
                         const noChatsDiv = document.createElement('div');
                         noChatsDiv.className = 'chat-item';
                         noChatsDiv.setAttribute('data-translate', 'noChats');
                         noChatsDiv.textContent = getTranslation('noChats', currentLang);
-                        container.innerHTML = '';
                         container.appendChild(noChatsDiv);
                     }
                     return;
                 }
 
-                // Procesar chats
-                const chats = [];
-                snapshot.forEach(doc => {
-                    // Evitar duplicados usando el Set
-                    if (!displayedChats.has(doc.id)) {
-                        const chatData = doc.data();
-                        chats.push({
-                            id: doc.id,
-                            ...chatData,
-                            lastMessageTime: chatData.lastMessageTime ? chatData.lastMessageTime.toDate() : new Date(0)
-                        });
-                        displayedChats.add(doc.id);
-                    }
-                });
+                const readTimes = getChatReadTimes();
 
-                // Ordenar chats por tiempo del último mensaje
-                chats.sort((a, b) => b.lastMessageTime - a.lastMessageTime);
-
-                // Mostrar chats
-                for (const chat of chats) {
-                    try {
-                        // Verificar si el chat ya está mostrado
-                        if (container && container.querySelector(`[data-chat-id="${chat.id}"]`)) {
-                            continue;
-                        }
-
-                        const chatElement = document.createElement('div');
-                        chatElement.className = 'chat-item';
-                        chatElement.setAttribute('data-chat-id', chat.id);
-                        
-                        if (chat.type === 'group') {
-                            chatElement.classList.add('group-chat');
-                        }
-                        if (chat.id === currentChat) {
-                            chatElement.classList.add('active');
-                        }
-
-                        let chatName = '';
-                        if (chat.type === 'group') {
-                            chatName = chat.name;
-                        } else {
-                            const otherUserId = chat.participants.find(id => id !== currentUser.uid);
-                            if (otherUserId) {
-                                const otherUserDoc = await getDoc(doc(db, 'users', otherUserId));
-                                if (otherUserDoc.exists()) {
-                                    const otherUserData = otherUserDoc.data();
-                                    chatName = otherUserData.username || otherUserData.email.split('@')[0];
-                                }
+                const chats = await Promise.all(snapshot.docs.map(async docSnap => {
+                    const data = docSnap.data();
+                    let name = '';
+                    if (data.type === 'group') {
+                        name = data.name;
+                    } else {
+                        const otherId = data.participants.find(id => id !== currentUser.uid);
+                        if (otherId) {
+                            const otherDoc = await getDoc(doc(db, 'users', otherId));
+                            if (otherDoc.exists()) {
+                                const od = otherDoc.data();
+                                name = od.username || od.email.split('@')[0];
                             }
                         }
-
-                        const lastMessageTime = chat.lastMessageTime ? 
-                            chat.lastMessageTime.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }) : '';
-
-                        chatElement.innerHTML = `
-                            <div class="chat-info">
-                                <div class="chat-details">
-                                    <div class="chat-name">${chatName}</div>
-                                    <div class="last-message">${chat.lastMessage || ''}</div>
-                                </div>
-                                <div class="last-message-time">${lastMessageTime}</div>
-                            </div>
-                            <button class="delete-chat-btn" title="${getTranslation('deleteChat', userLanguage)}">
-                                <i class="fas fa-trash"></i>
-                            </button>
-                        `;
-
-                        // Evento para borrar chat
-                        const deleteBtn = chatElement.querySelector('.delete-chat-btn');
-                        deleteBtn.addEventListener('click', (e) => {
-                            e.stopPropagation();
-                            showDeleteConfirmDialog(chat.id, chatElement);
-                        });
-
-                        chatElement.addEventListener('click', () => {
-                            console.log('👆 Abriendo chat:', chat.id);
-                            document.querySelectorAll('.chat-item').forEach(item => item.classList.remove('active'));
-                            chatElement.classList.add('active');
-                            openChat(chat.id);
-                        });
-
-                        if (container) {
-                            container.appendChild(chatElement);
-                        }
-                    } catch (error) {
-                        console.error('❌ Error al procesar chat individual:', error);
                     }
+
+                    const lastMsgTime = data.lastMessageTime ? data.lastMessageTime.toDate() : new Date(0);
+                    const unread = lastMsgTime.getTime() > (readTimes[docSnap.id] || 0);
+
+                    return {
+                        id: docSnap.id,
+                        name,
+                        isUnread: unread,
+                        lastMessageTime: lastMsgTime,
+                        lastMessage: data.lastMessage || '',
+                        type: data.type,
+                        participants: data.participants
+                    };
+                }));
+
+                chats.sort((a, b) => b.lastMessageTime - a.lastMessageTime);
+
+                for (const chat of chats) {
+                    const chatElement = document.createElement('div');
+                    chatElement.className = 'chat-item';
+                    chatElement.setAttribute('data-chat-id', chat.id);
+
+                    if (chat.type === 'group') chatElement.classList.add('group-chat');
+                    if (chat.id === currentChat) chatElement.classList.add('active');
+                    if (chat.isUnread) chatElement.classList.add('unread', 'chat-updated');
+
+                    const lastTime = chat.lastMessageTime ?
+                        chat.lastMessageTime.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }) : '';
+
+                    chatElement.innerHTML = `
+                        <div class="chat-info">
+                            <div class="chat-details">
+                                <div class="chat-name">${chat.name}</div>
+                                <div class="last-message">${chat.lastMessage}</div>
+                            </div>
+                            <div class="last-message-time">${lastTime}</div>
+                        </div>
+                        <button class="delete-chat-btn" title="${getTranslation('deleteChat', userLanguage)}">
+                            <i class="fas fa-trash"></i>
+                        </button>
+                    `;
+
+                    const deleteBtn = chatElement.querySelector('.delete-chat-btn');
+                    deleteBtn.addEventListener('click', (e) => {
+                        e.stopPropagation();
+                        showDeleteConfirmDialog(chat.id, chatElement);
+                    });
+
+                    chatElement.addEventListener('click', () => {
+                        document.querySelectorAll('.chat-item').forEach(item => item.classList.remove('active'));
+                        chatElement.classList.remove('unread', 'chat-updated');
+                        chatElement.classList.add('active');
+                        openChat(chat.id);
+                    });
+
+                    if (container) container.appendChild(chatElement);
                 }
             } catch (error) {
                 console.error('❌ Error al procesar actualización de chats:', error);
-                if (container && displayedChats.size === 0) {
+                if (container) {
                     container.innerHTML = `<div class="chat-item error">${getTranslation('errorLoadingChats', userLanguage)}</div>`;
                 }
             }
         }, error => {
             console.error('❌ Error en la suscripción de chats:', error);
-            if (container && displayedChats.size === 0) {
+            if (container) {
                 container.innerHTML = `<div class="chat-item error">${getTranslation('errorLoadingChats', userLanguage)}</div>`;
             }
         });
@@ -1452,6 +1420,12 @@ async function openChat(chatId) {
     lastVisibleMessage = null;
 
     currentChat = chatId;
+
+    // Limpia cualquier manejador previo en la cabecera del chat
+    if (currentChatInfo) {
+        currentChatInfo.onclick = null;
+        currentChatInfo.removeAttribute('title');
+    }
     
     try {
         // Obtener información del chat
@@ -1465,7 +1439,11 @@ async function openChat(chatId) {
         console.log('Datos del chat:', chatData);
         currentChatParticipants = chatData.participants || [];
         if (addMembersBtn) {
-            addMembersBtn.style.display = chatData.type === 'group' ? 'block' : 'none';
+            if (chatData.type === 'group') {
+                addMembersBtn.classList.remove('hidden');
+            } else {
+                addMembersBtn.classList.add('hidden');
+            }
         }
 
         // Limpiar mensajes anteriores
@@ -1528,6 +1506,7 @@ async function openChat(chatId) {
 
         // Cargar mensajes iniciales
         await loadInitialMessages(chatId);
+        markChatAsRead(chatId);
 
         // Suscribirse a nuevos mensajes
         const messagesRef = collection(db, 'chats', chatId, 'messages');
@@ -1586,6 +1565,7 @@ unsubscribeMessages = onSnapshot(newMessagesQuery, (snapshot) => {
             if (messagesList) {
                 messagesList.scrollTop = messagesList.scrollHeight;
             }
+            markChatAsRead(chatId);
         }
     });
 });
@@ -1714,6 +1694,31 @@ async function loadMoreMessages(chatId) {
     }
 }
 
+// Guardar la marca de lectura de un chat
+function markChatAsRead(chatId) {
+    try {
+        const times = JSON.parse(localStorage.getItem('chatReadTimes') || '{}');
+        times[chatId] = Date.now();
+        localStorage.setItem('chatReadTimes', JSON.stringify(times));
+    } catch (e) {
+        console.warn('LocalStorage unavailable, unread state not persisted', e);
+    }
+
+    const chatEl = document.querySelector(`[data-chat-id="${chatId}"]`);
+    if (chatEl) {
+        chatEl.classList.remove('unread');
+    }
+}
+
+function getChatReadTimes() {
+    try {
+        return JSON.parse(localStorage.getItem('chatReadTimes') || '{}');
+    } catch (e) {
+        console.warn('LocalStorage unavailable, using empty read times', e);
+        return {};
+    }
+}
+
 // Funciones auxiliares para la interfaz
 async function setupGroupChatInterface(chatData) {
     const participantsInfo = await Promise.all(
@@ -1723,14 +1728,21 @@ async function setupGroupChatInterface(chatData) {
         })
     );
 
+    const participantNames = participantsInfo.map(
+        user => user.username || user.email.split('@')[0]
+    );
+
     const groupInfoElement = document.createElement('div');
     groupInfoElement.className = 'group-info';
     groupInfoElement.innerHTML = `
         <div class="group-name">${chatData.name}</div>
         <div class="group-participants">
-            ${participantsInfo.map(user => user.username || user.email.split('@')[0]).join(', ')}
+            ${participantNames.join(', ')}
         </div>
     `;
+
+    groupInfoElement.title = participantNames.join(', ');
+    groupInfoElement.onclick = () => alert(participantNames.join(', '));
 
     if (currentChatInfo) {
         currentChatInfo.innerHTML = '';
@@ -2043,7 +2055,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 showAddMembersModal(currentChat, currentChatParticipants);
             }
         });
-        addBtn.style.display = 'none';
+        addBtn.classList.add('hidden');
     }
 });
 
@@ -2074,7 +2086,7 @@ function toggleChatList(show) {
         }
 
         if (addBtn) {
-            addBtn.style.display = 'none';
+            addBtn.classList.add('hidden');
         }
 
         // Restablecer estado del chat actual
@@ -2084,6 +2096,8 @@ function toggleChatList(show) {
         }
         if (currentChatInfo) {
             currentChatInfo.textContent = getTranslation('selectChat', userLanguage);
+            currentChatInfo.onclick = null;
+            currentChatInfo.removeAttribute('title');
         }
 
         // Recargar la lista de chats
@@ -2106,7 +2120,7 @@ function toggleChatList(show) {
     }
 
     if (addBtn && show) {
-        addBtn.style.display = 'none';
+        addBtn.classList.add('hidden');
     }
 
     adjustMobileLayout();

--- a/public/index.html
+++ b/public/index.html
@@ -212,7 +212,7 @@
                     <span class="material-icons">arrow_back</span>
                 </button>
                 <div id="currentChatInfo" data-translate="selectChat">Selecciona un chat para comenzar</div>
-                <button id="addMembersBtn" class="icon-button hidden" title="Agregar miembros" data-translate="addMembers">
+                <button id="addMembersBtn" class="icon-button hidden" title="Agregar miembros">
                     <i class="fas fa-user-plus"></i>
                 </button>
             </div>

--- a/public/styles.css
+++ b/public/styles.css
@@ -17,6 +17,7 @@
     --color-user-right: #fde1d9;
     --color-system: #8e8e8e;
     --color-system-bg: #faf2e3cc;
+    --color-unread: #fff6d1;
     --color-text: #4a3b00;
   }
   
@@ -31,6 +32,7 @@
     --color-user-right: #d4dfea;
     --color-system: #a3a9b1;
     --color-system-bg: #eef3facc;
+    --color-unread: #ffecec;
      --color-text: #1a2d48;
   }
   
@@ -45,6 +47,7 @@
     --color-user-right: #ffe9e9;
     --color-system: #9ea9a2;
     --color-system-bg: #f0f8f2cc;
+    --color-unread: #ffecec;
      --color-text: #1f4a33;
   }
   
@@ -63,7 +66,8 @@
     --color-user-right: #dfcef7;
     --color-system: #9c9cae;
     --color-system-bg: #f2eefacc;
-     --color-text: #443c5c; 
+    --color-unread: #ede5fa;
+     --color-text: #443c5c;
   }
   
   .theme-set-elegante.theme-en {
@@ -77,6 +81,7 @@
     --color-user-right: #d0e3f7;
     --color-system: #9aa7b5;
     --color-system-bg: #eef3facc;
+    --color-unread: #e6eef8;
      --color-text: #2c4564;
   }
   
@@ -91,6 +96,7 @@
     --color-user-right: #f5cfcf;
     --color-system: #a89e9e;
     --color-system-bg: #fff1f1cc;
+    --color-unread: #ffeaea;
      --color-text: #6c3f3f;
   }
   
@@ -109,6 +115,7 @@
     --color-user-right: #ffddb8;
     --color-system: #a08877;
     --color-system-bg: #fff1e7cc;
+    --color-unread: #fff0e0;
      --color-text: #5e3b19;
   }
   
@@ -123,7 +130,8 @@
     --color-user-right: #b2ebf2;
     --color-system: #779fa1;
     --color-system-bg: #e8f8facc;
-     --color-text: #02575e; 
+    --color-unread: #e0f7fa;
+     --color-text: #02575e;
   }
   
   .theme-set-creativo.theme-it {
@@ -137,7 +145,8 @@
     --color-user-right: #fdd5ed;
     --color-system: #a98ca2;
     --color-system-bg: #fff0f7cc;
-     --color-text: #6a3262; 
+    --color-unread: #ffe5f4;
+     --color-text: #6a3262;
   }
   
   /* =============================================================
@@ -156,7 +165,8 @@
     --color-user-right: #d0e8d0;
     --color-system: #8e9e8e;
     --color-system-bg: #f0f6f0cc;
-     --color-text: #3c553c; 
+    --color-unread: #eef6ee;
+     --color-text: #3c553c;
   }
   
   .theme-set-elegante2.theme-en {
@@ -170,7 +180,8 @@
     --color-user-right: #cdd9e4;
     --color-system: #8a9aa7;
     --color-system-bg: #eef3f7cc;
-     --color-text: #2e3f51; 
+    --color-unread: #e7edf3;
+     --color-text: #2e3f51;
   }
   
   .theme-set-elegante2.theme-it {
@@ -184,6 +195,7 @@
     --color-user-right: #f1e1ce;
     --color-system: #a89f96;
     --color-system-bg: #f7f1eacc;
+    --color-unread: #f9f4ed;
      --color-text: #5c4433;
   }
   
@@ -202,6 +214,7 @@
       --color-user-right: #b9f5d8;
       --color-system: #98a6a9;
       --color-system-bg: #f0f8f2cc;
+      --color-unread: #fff6d1;
       
       /* Colores de texto y estados */
       --color-text: #232f2b;
@@ -482,6 +495,31 @@
       flex: 1;
       min-width: 0;
   }
+
+  /* Información del chat grupal */
+  .group-info {
+      display: flex;
+      flex-direction: column;
+      flex: 1;
+      min-width: 0;
+      overflow: hidden;
+      cursor: pointer;
+  }
+
+  .group-name {
+      font-weight: 700;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+  }
+
+  .group-participants {
+      font-size: 0.85rem;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      color: #333;
+  }
   
   
   /* ==========================================================================
@@ -523,6 +561,11 @@
   
   .chat-item.active {
       background-color: var(--color-user-left);
+      border-left: 3px solid var(--color-primary);
+  }
+
+  .chat-item.unread {
+      background-color: var(--color-unread);
       border-left: 3px solid var(--color-primary);
   }
   
@@ -1242,10 +1285,11 @@
   #createGroup {
       background: #2e7d32;
   }
-  
+
   #createGroup:hover {
       background: #1b5e20;
   }
+
   
   #logoutBtn {
       background: var(--color-danger);
@@ -2098,9 +2142,9 @@
   }
 
 .chat-item.unread {
-  background-color: rgba(0, 200, 100, 0.08);
+  background-color: var(--color-unread);
   font-weight: bold;
-  border-left: 4px solid #00c864;
+  border-left: 4px solid var(--color-primary);
 }
 
 /* ==========================================================================


### PR DESCRIPTION
## Summary
- theme-specific `--color-unread` variables for better highlight colors
- unified unread chat styling
- guarded localStorage usage so iOS won't break realtime updates

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684027085dec832d9b6348231c421274