### PR TITLE
Fix typing indicator placement

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -217,10 +217,9 @@
                 </button>
             </div>
             <div id="messagesList" class="messages-list">
-            <div id="typingIndicator" style="display:none; font-style: italic; padding: 5px 10px; color: #555;"></div>
-
                 <!-- Los mensajes se cargarán aquí dinámicamente -->
             </div>
+            <div id="typingIndicator" style="display:none; font-style: italic; padding: 5px 10px; color: #555;"></div>
             <div class="message-input">
                 <button id="micButton" class="icon-button" title="Grabar audio">
                     <i class="fas fa-microphone"></i>

--- a/public/styles.css
+++ b/public/styles.css
@@ -1080,6 +1080,7 @@
   /* Indicador de Escritura */
   #typingIndicator {
       padding: 5px 10px;
+      margin: 5px;
       font-style: italic;
       color: var(--color-system);
       text-align: center;


### PR DESCRIPTION
## Summary
- show typing indicator below message list so it's visible
- add small margin to the typing indicator

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68404d5308c4832d81c3501d5556b5fe