### PR TITLE
Improve typing indicator

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -217,8 +217,7 @@
                 </button>
             </div>
             <div id="messagesList" class="messages-list">
-            <div id="typingIndicator" style="display:none; font-style: italic; padding: 5px 10px; color: #555;"></div>
-
+                <div id="typingIndicator" style="display:none; font-style: italic; padding: 5px 10px; color: #555;"></div>
                 <!-- Los mensajes se cargarán aquí dinámicamente -->
             </div>
             <div class="message-input">

--- a/public/styles.css
+++ b/public/styles.css
@@ -1080,10 +1080,14 @@
   /* Indicador de Escritura */
   #typingIndicator {
       padding: 5px 10px;
+      margin: 5px;
       font-style: italic;
       color: var(--color-system);
       text-align: center;
       animation: fadeIn 0.3s ease;
+      position: sticky;
+      bottom: 0;
+      background: var(--color-bg-alt);
   }
   
   /* Mensajes del Sistema */


### PR DESCRIPTION
## Summary
- place typing indicator back inside the message list
- keep it visible with sticky positioning

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68404d5308c4832d81c3501d5556b5fe