### PR TITLE
Add typing indicator message

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -38,7 +38,7 @@ import {
 import { getMessaging, getToken, onMessage } from 'https://www.gstatic.com/firebasejs/10.7.1/firebase-messaging.js';
 import { initializeApp } from 'https://www.gstatic.com/firebasejs/10.7.1/firebase-app.js';
 
-import { translations, getTranslation, translateInterface, animateTitleWave, getTypingText } from './translations.js';
+import { translations, getTranslation, translateInterface, animateTitleWave, getTypingText, getTypingMessage } from './translations.js';
 import { translateText, getFlagEmoji, AVAILABLE_LANGUAGES } from './translation-service.js';
 
 import { auth } from './modules/firebase.js'; // Esto lo importa de forma limpia y segura
@@ -1546,10 +1546,10 @@ unsubscribeMessagesFn = onSnapshot(newMessagesQuery, (snapshot) => {
         console.log('🌐 Idioma actual para indicador de escritura:', currentLang);
 
         if (typingStatus && typingStatus.userId && typingStatus.userId !== currentUser.uid) {
-            const typingText = getTypingText(currentLang);
             const username = typingStatus.username || typingStatus.userId;
+            const typingMessage = getTypingMessage(username, currentLang);
             console.log('💬 Usuario escribiendo:', username);
-            showTypingIndicator(`${username} ${typingText}`);
+            showTypingIndicator(typingMessage);
         } else {
             console.log('💬 Nadie está escribiendo');
             hideTypingIndicator();

--- a/public/translations.js
+++ b/public/translations.js
@@ -386,5 +386,12 @@ export function getTypingText(lang) {
     return fallbackMessages[lang] || 'is typing...';
 }
 
+export function getTypingMessage(username, lang) {
+    if (translations[lang] && translations[lang].userIsTyping) {
+        return translations[lang].userIsTyping.replace('{user}', username);
+    }
+    return `${username} ${getTypingText(lang)}`;
+}
+
 // Exportar todo junto al final
 export { translations, getTranslation, translateInterface, animateTitleWave };


### PR DESCRIPTION
## Summary
- detect when other users are typing and show translated typing indicator
- support typed message translation with username

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684055d7408c832d8c6128430698634b