### PR TITLE
Add FCM server key env variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,4 @@ FIREBASE_PROJECT_ID=your_project_id_here
 FIREBASE_STORAGE_BUCKET=your_storage_bucket_here
 FIREBASE_MESSAGING_SENDER_ID=your_messaging_sender_id_here
 FIREBASE_APP_ID=your_app_id_here
+FCM_SERVER_KEY=

--- a/README.md
+++ b/README.md
@@ -21,15 +21,19 @@ Una aplicación de chat con traducción automática integrada. Los usuarios pued
 
 1. Clona este repositorio
 2. Instala las dependencias con `npm install`
-3. Configura las variables de entorno necesarias
-4. Ejecuta el servidor con `npm start`
+3. Configura las variables de entorno necesarias (incluye `FCM_SERVER_KEY` para
+   las notificaciones FCM)
+4. Ejecuta el servidor con `npm start`. Asegúrate de que las variables de
+   entorno estén cargadas previamente.
 
 ## Configuración
 
 1. Crea un proyecto en Firebase
 2. Configura las credenciales en `firebase-config.js`
 3. Habilita la autenticación por email en Firebase
-4. Configura las variables de entorno necesarias
+4. Configura las variables de entorno necesarias. En el archivo `.env` deberás incluir
+   todas las claves de Firebase y **FCM_SERVER_KEY** para poder enviar notificaciones
+   push mediante FCM.
 
 ## Contribuir
 


### PR DESCRIPTION
## Summary
- include `FCM_SERVER_KEY` in `.env.example`
- document the variable in installation and configuration sections

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68400e18684c832dbe5afe0f7af72218