### PR TITLE
Implement token refresh and cleanup service worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ innecesarias a la API y así ahorrar tiempo y créditos.
    todas las claves de Firebase y **FCM_SERVER_KEY** para poder enviar notificaciones
    push mediante FCM.
 
+## Compatibilidad
+
+Las notificaciones push basadas en FCM no funcionan en Safari para iOS debido a la
+falta de soporte para Service Workers. Si necesitas notificar a los usuarios de iOS,
+considera alternativas como correos electrónicos o mensajes SMS.
+
 ## Contribuir
 
 Las contribuciones son bienvenidas. Por favor, abre un issue primero para discutir los cambios que te gustaría hacer. 

--- a/public/index.html
+++ b/public/index.html
@@ -304,17 +304,5 @@
     <script type="module" src="translations.js"></script>
     <script type="module" src="app.js"></script>
     
-    <!-- Registro del Service Worker -->
-    <script>
-        if ('serviceWorker' in navigator) {
-            navigator.serviceWorker.register('/firebase-messaging-sw.js')
-                .then(function(registration) {
-                    console.log('Service Worker registrado con éxito:', registration.scope);
-                })
-                .catch(function(error) {
-                    console.log('Error al registrar el Service Worker:', error);
-                });
-        }
-    </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- implement FCM token refresh and update Firestore when token changes
- pass the service worker registration to `getToken`
- remove duplicate service worker registration from `index.html`
- document iOS Safari push limitations

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6841422fa768832dae39c01ab329de42