### PR TITLE
Add Web Speech API playback for translated messages

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -1586,6 +1586,16 @@ select:focus-visible {
   margin: 0 3px;
 }
 
+.speak-button {
+  background: none;
+  border: none;
+  padding: 0 2px;
+  cursor: pointer;
+  color: inherit;
+  display: flex;
+  align-items: center;
+}
+
 .message-time {
   font-size: 0.65em;
   color: rgba(134, 150, 160, 0.9);


### PR DESCRIPTION
## Summary
- add speech synthesis utilities
- show a volume button next to each message
- speak new incoming messages automatically
- style volume button in message bubbles

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6841682c55a0832daa8352afad6c3ab4