### PR TITLE
Fix layout for add members button on small screens

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -496,6 +496,13 @@ body {
   min-width: 0;
 }
 
+/* Contenedor de información del chat actual */
+#currentChatInfo {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+}
+
 /* Información del chat grupal */
 .group-info {
   display: flex;
@@ -744,6 +751,7 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
+  flex-shrink: 0;
   cursor: pointer;
   transition: var(--transition);
 }


### PR DESCRIPTION
## Summary
- ensure chat info container flexes without pushing buttons out
- prevent icon buttons from shrinking

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68416d355c6c832db5b2f8f1f9074c65