### PR TITLE
Implement toast notifications

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -251,7 +251,7 @@ function startTimer(duration) {
 function simulateSendSMS(phoneNumber, code) {
     console.log(`Código enviado a ${phoneNumber}: ${code}`);
     // En una implementación real, aquí se llamaría a un servicio de SMS
-    alert(getTranslation('demoVerificationCode', getUserLanguage(), code));
+    showToast(getTranslation('demoVerificationCode', getUserLanguage(), code));
 }
 
 // Función para enviar el código vía API
@@ -273,7 +273,7 @@ async function sendVerificationCode(phoneNumber) {
         return true;
     } catch (error) {
         console.error('Error al enviar código:', error);
-        alert(getTranslation('errorSendingCode', getUserLanguage(), error.message));
+        showToast(getTranslation('errorSendingCode', getUserLanguage(), error.message));
         return false;
     }
 }
@@ -293,14 +293,34 @@ async function verifyCode(phoneNumber, code) {
         return data.success;
     } catch (error) {
         console.error('Error al verificar código:', error);
-        alert(getTranslation('errorVerifyingCode', getUserLanguage(), error.message));
+        showToast(getTranslation('errorVerifyingCode', getUserLanguage(), error.message));
         return false;
     }
 }
 
 // Función para mostrar mensajes de error
+function showToast(message) {
+    let container = document.getElementById('toastContainer');
+    if (!container) {
+        container = document.createElement('div');
+        container.id = 'toastContainer';
+        container.className = 'toast-container';
+        document.body.appendChild(container);
+    }
+
+    const toast = document.createElement('div');
+    toast.className = 'toast';
+    toast.textContent = message;
+    container.appendChild(toast);
+
+    setTimeout(() => {
+        toast.remove();
+    }, 4000);
+}
+window.showToast = showToast;
+
 function showError(errorKey) {
-    alert(getTranslation(errorKey, getUserLanguage()));
+    showToast(getTranslation(errorKey, getUserLanguage()));
 }
 
 // Función para actualizar la información del usuario
@@ -366,7 +386,7 @@ loginBtn.addEventListener('click', async () => {
 
     const usernameRegex = /^[a-zA-Z0-9_-]{3,20}$/;
     if (!usernameRegex.test(username)) {
-        alert(getTranslation('errorUsernameChars', getUserLanguage()));
+        showToast(getTranslation('errorUsernameChars', getUserLanguage()));
         return;
     }
 
@@ -412,7 +432,7 @@ loginBtn.addEventListener('click', async () => {
                 showError('errorNetwork');
                 break;
             case 'auth/too-many-requests':
-                alert(getTranslation('errorTooManyAttempts', getUserLanguage()));
+                showToast(getTranslation('errorTooManyAttempts', getUserLanguage()));
                 break;
             default:
                 showError('errorGeneric');
@@ -863,7 +883,7 @@ async function deleteChat(chatId) {
         await batch.commit();
 
         // Mostrar mensaje de éxito
-        alert(getTranslation('chatDeleted', getUserLanguage()));
+        showToast(getTranslation('chatDeleted', getUserLanguage()));
 
     } catch (error) {
         console.error('Error al borrar chat:', error);
@@ -1831,7 +1851,7 @@ async function setupGroupChatInterface(chatData) {
     `;
 
     groupInfoElement.title = participantNames.join(', ');
-    groupInfoElement.onclick = () => alert(participantNames.join(', '));
+    groupInfoElement.onclick = () => showToast(participantNames.join(', '));
 
     if (currentChatInfo) {
         currentChatInfo.innerHTML = '';
@@ -1977,7 +1997,7 @@ async function sendMessage(text) {
                         translationStatus: 'limit_exceeded'
                     });
                     const limitMessage = getTranslation('translationLimitExceeded', currentLanguage);
-                    alert(limitMessage);
+                    showToast(limitMessage);
                     break;
                 } else {
                     console.log(`✅ Traducción a ${targetLang} completada:`, translation);
@@ -2112,10 +2132,10 @@ async function handleLogout() {
         showAuthScreen();
         
         // Mostrar mensaje de éxito
-        alert(getTranslation('logoutSuccess', getUserLanguage()));
+        showToast(getTranslation('logoutSuccess', getUserLanguage()));
     } catch (error) {
         console.error('Error al cerrar sesión:', error);
-        alert(getTranslation('errorGeneric', getUserLanguage()));
+        showToast(getTranslation('errorGeneric', getUserLanguage()));
     }
 }
 
@@ -2324,11 +2344,11 @@ function showMessageOptions(messageEl) {
         <button class="delete-btn" aria-label="Borrar">🗑</button>
     `;
     container.querySelector('.reply-btn').addEventListener('click', () => {
-        alert('Responder');
+        showToast('Responder');
         container.remove();
     });
     container.querySelector('.delete-btn').addEventListener('click', () => {
-        alert('Borrar');
+        showToast('Borrar');
         container.remove();
     });
     messageEl.appendChild(container);
@@ -2454,7 +2474,7 @@ function showGroupCreationModal() {
             await createGroupChat(groupName, Array.from(selectedUsers));
             modal.remove();
             // Mostrar mensaje de éxito
-            alert(getTranslation('groupCreated', getUserLanguage()));
+            showToast(getTranslation('groupCreated', getUserLanguage()));
         } catch (error) {
             console.error('Error al crear grupo:', error);
             showError('errorCreateGroup');
@@ -2700,7 +2720,7 @@ function showAddMembersModal(chatId, existingParticipants = []) {
         try {
             await addMembersToGroup(chatId, Array.from(selectedUsers));
             modal.remove();
-            alert(getTranslation('membersAdded', getUserLanguage()));
+            showToast(getTranslation('membersAdded', getUserLanguage()));
         } catch (err) {
             console.error('Error al agregar miembros:', err);
             showError('errorAddMembers');

--- a/public/index.html
+++ b/public/index.html
@@ -432,6 +432,7 @@
         console.error("Error al inicializar Firebase:", error);
       }
     </script>
+    <div id="toastContainer" class="toast-container"></div>
     <script type="module" src="translations.js"></script>
     <script type="module" src="app.js"></script>
   </body>

--- a/public/modules/notificaciones.js
+++ b/public/modules/notificaciones.js
@@ -4,17 +4,10 @@ import { doc, setDoc, serverTimestamp } from 'https://www.gstatic.com/firebasejs
 import { getToken, onMessage } from 'https://www.gstatic.com/firebasejs/10.7.1/firebase-messaging.js';
 
 function showForegroundToast(title, body) {
-    const toast = document.getElementById('inAppToast');
-    if (!toast) return;
-
-    toast.textContent = `${title}: ${body}`;
-    toast.classList.remove('hidden');
-    toast.classList.add('show');
-
-    setTimeout(() => {
-        toast.classList.remove('show');
-        toast.classList.add('hidden');
-    }, 4000);
+    if (typeof window.showToast === 'function') {
+        window.showToast(`${title}: ${body}`);
+        return;
+    }
 }
 
 export async function initializeNotifications() {

--- a/public/styles.css
+++ b/public/styles.css
@@ -2411,3 +2411,43 @@ select:focus-visible {
     transform: rotate(360deg);
   }
 }
+
+/* Toast notifications */
+.toast-container {
+  position: fixed;
+  bottom: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  z-index: 9999;
+}
+
+.toast {
+  background: var(--color-primary);
+  color: #fff;
+  padding: 10px 16px;
+  border-radius: 20px;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
+  opacity: 0;
+  transform: translateY(20px);
+  animation: toast-in-out 4s ease forwards;
+}
+
+@keyframes toast-in-out {
+  0% {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  10%,
+  90% {
+    opacity: 1;
+    transform: translateY(0);
+  }
+  100% {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+}


### PR DESCRIPTION
## Summary
- add a toast container to the main page
- implement toast styles
- create `showToast` utility and replace browser `alert()` usage
- update notifications module to use global toasts

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6841a17de8f4832d89701607a21ee510