### PR TITLE
Improve typing indicator with username

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -2065,7 +2065,7 @@ async function setTypingStatus(isTyping) {
         const typingData = isTyping ? {
             userId: currentUser.uid,
             timestamp: serverTimestamp(),
-            username: currentUser.email.split('@')[0] // o el nombre de usuario si lo tienes
+            username: currentUser.username || currentUser.email.split('@')[0]
         } : null;
 
         await updateDoc(chatRef, {

--- a/public/index.html
+++ b/public/index.html
@@ -325,15 +325,7 @@
         <div id="messagesList" class="messages-list">
           <!-- Los mensajes se cargarán aquí dinámicamente -->
         </div>
-        <div
-          id="typingIndicator"
-          style="
-            display: none;
-            font-style: italic;
-            padding: 5px 10px;
-            color: #555;
-          "
-        ></div>
+        <div id="typingIndicator"></div>
         <div class="message-input">
           <button id="micButton" class="icon-button" title="Grabar audio" aria-label="Grabar audio">
             <i class="fas fa-microphone"></i>

--- a/public/styles.css
+++ b/public/styles.css
@@ -1132,11 +1132,18 @@ body {
 
 /* Indicador de Escritura */
 #typingIndicator {
-  padding: 5px 10px;
-  margin: 5px;
+  position: absolute;
+  bottom: calc(var(--message-input-height));
+  left: 0;
+  width: 100%;
+  padding: 2px 10px;
+  margin: 0;
   font-style: italic;
+  font-size: 0.85em;
   color: var(--color-system);
   text-align: center;
+  pointer-events: none;
+  display: none;
   animation: fadeIn 0.3s ease;
 }
 


### PR DESCRIPTION
## Summary
- show username instead of email in typing status
- prevent the typing indicator from shifting the layout
- keep HTML clean

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6841b6ea25f8832da25841c706565976