### PR TITLE
Improve chat list updates and typing indicator

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -325,15 +325,7 @@
         <div id="messagesList" class="messages-list">
           <!-- Los mensajes se cargarán aquí dinámicamente -->
         </div>
-        <div
-          id="typingIndicator"
-          style="
-            display: none;
-            font-style: italic;
-            padding: 5px 10px;
-            color: #555;
-          "
-        ></div>
+        <div id="typingIndicator"></div>
         <div class="message-input">
           <button id="micButton" class="icon-button" title="Grabar audio" aria-label="Grabar audio">
             <i class="fas fa-microphone"></i>

--- a/public/styles.css
+++ b/public/styles.css
@@ -1132,11 +1132,18 @@ body {
 
 /* Indicador de Escritura */
 #typingIndicator {
-  padding: 5px 10px;
-  margin: 5px;
+  position: absolute;
+  bottom: calc(var(--message-input-height));
+  left: 0;
+  width: 100%;
+  padding: 2px 10px;
+  margin: 0;
   font-style: italic;
+  font-size: 0.85em;
   color: var(--color-system);
   text-align: center;
+  pointer-events: none;
+  display: none;
   animation: fadeIn 0.3s ease;
 }
 


### PR DESCRIPTION
## Summary
- reset `lastChatsKey` whenever a new chats query is set up
- ignore stale typingStatus entries using a 5s timeout

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6841b6ea25f8832da25841c706565976