### PR TITLE
Fix duplicated push notifications

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -218,6 +218,9 @@ let lastVisibleMessage = null;
 let lastProcessedMessageId = null; // Variable para evitar duplicados
 
 // Enviar notificaciones push a los participantes de un chat
+// Esta función quedó obsoleta ya que las notificaciones se manejan
+// mediante Cloud Functions al crear cada mensaje. Se mantiene por si se
+// requieren envíos manuales en el futuro, pero no se invoca desde el cliente.
 async function sendPushNotifications(chatData, messageText) {
     try {
         const sender = getCurrentUser();
@@ -2016,8 +2019,10 @@ async function sendMessage(text) {
         const chatData = chatDoc.data();
         const isGroupChat = chatData.type === 'group';
 
-        // Enviar notificaciones push a los demás participantes
-        sendPushNotifications(chatData, text.trim());
+        // Las notificaciones push ahora las envían las Cloud Functions al
+        // detectarse la creación del mensaje, por lo que no es necesario
+        // enviarlas manualmente desde el cliente.
+        // sendPushNotifications(chatData, text.trim());
         
         // Determinar los idiomas necesarios para traducción
         let targetLanguages = new Set();


### PR DESCRIPTION
## Summary
- remove call to send push notifications from client
- clarify obsolete helper function

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6842a5a16420832da1beac8280320cd7