### PR TITLE
Fix duplicate notifications and typing updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,4 +52,8 @@ pantalla de inicio para poder solicitar el permiso y recibirlas correctamente.
 
 ## Contribuir
 
-Las contribuciones son bienvenidas. Por favor, abre un issue primero para discutir los cambios que te gustaría hacer. 
+Las contribuciones son bienvenidas. Por favor, abre un issue primero para discutir los cambios que te gustaría hacer.
+
+### Cambios recientes
+
+- Se eliminó la duplicación de notificaciones push y se mejoró el manejo del estado de escritura para evitar parpadeos en la lista de chats.

--- a/firestore.rules
+++ b/firestore.rules
@@ -32,18 +32,25 @@ service cloud.firestore {
       
       // Reglas para mensajes dentro de chats
       match /messages/{messageId} {
-        allow read, create: if isAuthenticated() && 
+        allow read, create: if isAuthenticated() &&
                             get(/databases/$(database)/documents/chats/$(chatId))
                             .data.participants.hasAny([request.auth.uid]);
         // Modificar esta línea para permitir actualizaciones y borrado controlados
-        allow update: if isAuthenticated() && 
+        allow update: if isAuthenticated() &&
                      get(/databases/$(database)/documents/chats/$(chatId))
                      .data.participants.hasAny([request.auth.uid]) &&
                      request.resource.data.diff(resource.data).affectedKeys()
                      .hasOnly(['translations']);
-        allow delete: if isAuthenticated() && 
+        allow delete: if isAuthenticated() &&
                      get(/databases/$(database)/documents/chats/$(chatId))
                      .data.participants.hasAny([request.auth.uid]);
+      }
+
+      // Reglas para el estado de escritura en subcolección
+      match /typingStatus/{userId} {
+        allow read, write: if isAuthenticated() &&
+                           get(/databases/$(database)/documents/chats/$(chatId))
+                           .data.participants.hasAny([request.auth.uid]);
       }
     }
   }

--- a/public/firebase-messaging-sw.js
+++ b/public/firebase-messaging-sw.js
@@ -22,9 +22,16 @@ console.log('✅ Firebase Messaging inicializado en Service Worker');
 messaging.onBackgroundMessage((payload) => {
   console.log('📬 Recibido mensaje en background:', payload);
 
-  const notificationTitle = payload.notification.title;
+  // Si el mensaje incluye el campo notification, Firebase ya se encarga de
+  // mostrar la notificación. Solo se personaliza en caso de mensajes de datos
+  // para evitar notificaciones duplicadas.
+  if (payload.notification) {
+    return;
+  }
+
+  const notificationTitle = payload.data?.title || 'TraduChat';
   const notificationOptions = {
-    body: payload.notification.body,
+    body: payload.data?.body || '',
     icon: '/images/icon-192.png',
     badge: '/images/icon-72x72.png',
     vibrate: [200, 100, 200],
@@ -32,9 +39,12 @@ messaging.onBackgroundMessage((payload) => {
     data: payload.data
   };
 
-  console.log('🔔 Mostrando notificación:', { title: notificationTitle, options: notificationOptions });
+  console.log('🔔 Mostrando notificación personalizada:', {
+    title: notificationTitle,
+    options: notificationOptions
+  });
 
-  return self.registration.showNotification(notificationTitle, notificationOptions);
+  self.registration.showNotification(notificationTitle, notificationOptions);
 });
 
 // Manejar clic en la notificación


### PR DESCRIPTION
## Summary
- prevent duplicate push notifications in service worker
- track typing status in a dedicated subcollection
- update chat list logic to read typing subcollection
- clean typing state when closing chat
- document latest changes

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6842a821f150832d87573aa65ef798a8