### PR TITLE
Fix background push notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,4 @@ Las contribuciones son bienvenidas. Por favor, abre un issue primero para discut
 ### Cambios recientes
 
 - Se eliminó la duplicación de notificaciones push y se mejoró el manejo del estado de escritura para evitar parpadeos en la lista de chats.
+- Se ajustó el *service worker* para mostrar correctamente las notificaciones cuando la aplicación está en segundo plano.

--- a/public/firebase-messaging-sw.js
+++ b/public/firebase-messaging-sw.js
@@ -22,16 +22,10 @@ console.log('✅ Firebase Messaging inicializado en Service Worker');
 messaging.onBackgroundMessage((payload) => {
   console.log('📬 Recibido mensaje en background:', payload);
 
-  // Si el mensaje incluye el campo notification, Firebase ya se encarga de
-  // mostrar la notificación. Solo se personaliza en caso de mensajes de datos
-  // para evitar notificaciones duplicadas.
-  if (payload.notification) {
-    return;
-  }
-
-  const notificationTitle = payload.data?.title || 'TraduChat';
+  const notificationTitle =
+    payload.notification?.title || payload.data?.title || 'TraduChat';
   const notificationOptions = {
-    body: payload.data?.body || '',
+    body: payload.notification?.body || payload.data?.body || '',
     icon: '/images/icon-192.png',
     badge: '/images/icon-72x72.png',
     vibrate: [200, 100, 200],
@@ -39,7 +33,7 @@ messaging.onBackgroundMessage((payload) => {
     data: payload.data
   };
 
-  console.log('🔔 Mostrando notificación personalizada:', {
+  console.log('🔔 Mostrando notificación:', {
     title: notificationTitle,
     options: notificationOptions
   });


### PR DESCRIPTION
## Summary
- show push notifications from the service worker whether payload.notification or payload.data is used
- document the fix in README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6842aeda1c38832d97cabebcf186c20c