### PR TITLE
Fix undefined manualPushNotifications

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -151,6 +151,12 @@ let inMemoryReadTimes = {};
 let selectedUsers = new Set();
 let isGroupCreationMode = false;
 
+// Si se habilita, las notificaciones push se enviarán tanto
+// desde el cliente como desde las Cloud Functions, pudiendo
+// producir duplicados. Mantener en "true" para forzar los
+// envíos manuales de notificación.
+const manualPushNotifications = true;
+
 // Variables para grabación de audio
 let isRecording = false;
 


### PR DESCRIPTION
## Summary
- ensure `manualPushNotifications` is defined and enabled by default

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6842b2b1184c832da86899045e21fcde