### PR TITLE
Fix FCM server and avoid duplicated notifications

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,10 @@
   "license": "ISC",
   "dependencies": {
     "express": "^4.18.2",
-    "firebase": "^10.7.1"
+    "firebase": "^10.7.1",
+    "cors": "^2.8.5",
+    "body-parser": "^1.20.2",
+    "dotenv": "^16.4.5",
+    "node-fetch": "^3.3.2"
   }
-} 
+}

--- a/public/app.js
+++ b/public/app.js
@@ -155,7 +155,7 @@ let isGroupCreationMode = false;
 // desde el cliente como desde las Cloud Functions, pudiendo
 // producir duplicados. Mantener en "true" para forzar los
 // envíos manuales de notificación.
-const manualPushNotifications = true;
+const manualPushNotifications = false;
 
 // Variables para grabación de audio
 let isRecording = false;

--- a/server.js
+++ b/server.js
@@ -1,9 +1,16 @@
-const express = require('express');
-const cors = require('cors');
-const bodyParser = require('body-parser');
-const path = require('path');
-const fetch = (...args) => import('node-fetch').then(({default: fetch}) => fetch(...args));
-require('dotenv').config();
+import express from 'express';
+import cors from 'cors';
+import bodyParser from 'body-parser';
+import path from 'path';
+import fetch from 'node-fetch';
+import dotenv from 'dotenv';
+import { fileURLToPath } from 'url';
+import { dirname } from 'path';
+
+dotenv.config();
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
 
 const app = express();
 
@@ -74,4 +81,4 @@ if (process.env.NODE_ENV !== 'production') {
 }
 
 // Exportar la app para Vercel
-module.exports = app; 
+export default app;


### PR DESCRIPTION
## Summary
- fix Express server to work with ES modules
- add missing dependencies (`node-fetch`, `cors`, `body-parser`, `dotenv`)
- disable manual push notifications to avoid duplicates when Cloud Functions send them

## Testing
- `npm start` *(fails: Cannot find package 'express')*

------
https://chatgpt.com/codex/tasks/task_e_6842c4f8ec44832da0b2e87c6347f127