### PR TITLE
Fix FCM notification API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,5 @@ FIREBASE_STORAGE_BUCKET=your_storage_bucket_here
 FIREBASE_MESSAGING_SENDER_ID=your_messaging_sender_id_here
 FIREBASE_APP_ID=your_app_id_here
 FCM_SERVER_KEY=
+FIREBASE_SERVICE_ACCOUNT=
+FCM_PROJECT_ID=

--- a/README.md
+++ b/README.md
@@ -28,14 +28,18 @@ innecesarias a la API y así ahorrar tiempo y créditos.
 
 1. Clona este repositorio
 2. Instala las dependencias con `npm install`
-3. Configura las variables de entorno necesarias (incluye `FCM_SERVER_KEY` para
-   las notificaciones FCM)
+3. Configura las variables de entorno necesarias. Para las notificaciones puedes
+   usar la clave del servidor `FCM_SERVER_KEY` (API legacy) o, de preferencia,
+   definir `FIREBASE_SERVICE_ACCOUNT` (JSON de la cuenta de servicio) junto con
+   `FCM_PROJECT_ID` para emplear la API HTTP v1 de FCM.
 4. Ejecuta el servidor con `npm start`. Asegúrate de que las variables de
    entorno estén cargadas previamente.
 
-   Si al desplegar en Vercel obtienes un error relacionado con un HTML en lugar
-   de la respuesta JSON de FCM, verifica que la variable `FCM_SERVER_KEY` esté
-   correctamente configurada en el panel de entorno de Vercel.
+   Si al desplegar en Vercel obtienes un error con una página HTML en la
+   respuesta de FCM, revisa que las variables de notificación estén correctamente
+   definidas. Si usas la clave de servidor, comprueba `FCM_SERVER_KEY`. Si optas
+   por la API HTTP v1, asegúrate de incluir `FIREBASE_SERVICE_ACCOUNT` y
+   `FCM_PROJECT_ID`.
 
 ## Configuración
 
@@ -43,8 +47,9 @@ innecesarias a la API y así ahorrar tiempo y créditos.
 2. Configura las credenciales en `firebase-config.js`
 3. Habilita la autenticación por email en Firebase
 4. Configura las variables de entorno necesarias. En el archivo `.env` deberás incluir
-   todas las claves de Firebase y **FCM_SERVER_KEY** para poder enviar notificaciones
-   push mediante FCM.
+   las claves de Firebase y los valores para enviar notificaciones. Puedes optar por
+   la clave de servidor (**FCM_SERVER_KEY**) o definir **FIREBASE_SERVICE_ACCOUNT**
+   junto a **FCM_PROJECT_ID** para utilizar la API HTTP v1.
 
 ## Compatibilidad
 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "firebase": "^10.7.1",
     "cors": "^2.8.5",
     "body-parser": "^1.20.2",
-    "dotenv": "^16.4.5"
+    "dotenv": "^16.4.5",
+    "google-auth-library": "^9.0.0"
   }
 }

--- a/server.js
+++ b/server.js
@@ -5,6 +5,7 @@ import path from 'path';
 // import dotenv from 'dotenv';
 import { fileURLToPath } from 'url';
 import { dirname } from 'path';
+import { GoogleAuth } from 'google-auth-library';
 
 // dotenv.config();
 
@@ -25,27 +26,67 @@ app.use(express.static(path.join(__dirname, 'public')));
 app.post('/api/send-notification', async (req, res) => {
     const { token, title, body, data: extraData } = req.body;
 
-    if (!process.env.FCM_SERVER_KEY) {
-        return res.status(500).json({ error: 'FCM_SERVER_KEY not configured' });
+    const serviceAccount = process.env.FIREBASE_SERVICE_ACCOUNT;
+    const projectId = process.env.FCM_PROJECT_ID;
+    const serverKey = process.env.FCM_SERVER_KEY;
+
+    if (!serviceAccount && !serverKey) {
+        return res.status(500).json({ error: 'FCM credentials not configured' });
     }
 
     try {
-        const response = await fetch('https://fcm.googleapis.com/fcm/send', {
-            method: 'POST',
-            headers: {
-                'Authorization': `key=${process.env.FCM_SERVER_KEY}`,
-                'Content-Type': 'application/json'
-            },
-            body: JSON.stringify({
-                to: token,
-                notification: {
-                    title,
-                    body,
-                    icon: '/images/icon-192.png'
+        let response;
+
+        if (serviceAccount && projectId) {
+            // Preferir la API HTTP v1 si se proporciona una cuenta de servicio
+            const credentials = JSON.parse(serviceAccount);
+            const auth = new GoogleAuth({
+                credentials,
+                scopes: ['https://www.googleapis.com/auth/firebase.messaging']
+            });
+            const client = await auth.getClient();
+            const accessToken = await client.getAccessToken();
+
+            response = await fetch(
+                `https://fcm.googleapis.com/v1/projects/${projectId}/messages:send`,
+                {
+                    method: 'POST',
+                    headers: {
+                        Authorization: `Bearer ${accessToken.token || accessToken}`,
+                        'Content-Type': 'application/json'
+                    },
+                    body: JSON.stringify({
+                        message: {
+                            token,
+                            notification: {
+                                title,
+                                body,
+                                icon: '/images/icon-192.png'
+                            },
+                            data: extraData
+                        }
+                    })
+                }
+            );
+        } else {
+            // Uso de la API legacy con la clave del servidor
+            response = await fetch('https://fcm.googleapis.com/fcm/send', {
+                method: 'POST',
+                headers: {
+                    Authorization: `key=${serverKey}`,
+                    'Content-Type': 'application/json'
                 },
-                data: extraData
-            })
-        });
+                body: JSON.stringify({
+                    to: token,
+                    notification: {
+                        title,
+                        body,
+                        icon: '/images/icon-192.png'
+                    },
+                    data: extraData
+                })
+            });
+        }
 
         const text = await response.text();
         let responseData;


### PR DESCRIPTION
## Summary
- support HTTP v1 FCM by using a service account
- document new variables for FCM API usage
- add env variable examples

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6842ca5eb2b4832dbbdf168095dcd654