### PR TITLE
Simplify FCM notification endpoint

### DIFF
--- a/server.js
+++ b/server.js
@@ -5,7 +5,6 @@ import path from 'path';
 // import dotenv from 'dotenv';
 import { fileURLToPath } from 'url';
 import { dirname } from 'path';
-import { GoogleAuth } from 'google-auth-library';
 
 // dotenv.config();
 
@@ -26,67 +25,29 @@ app.use(express.static(path.join(__dirname, 'public')));
 app.post('/api/send-notification', async (req, res) => {
     const { token, title, body, data: extraData } = req.body;
 
-    const serviceAccount = process.env.FIREBASE_SERVICE_ACCOUNT;
-    const projectId = process.env.FCM_PROJECT_ID;
     const serverKey = process.env.FCM_SERVER_KEY;
 
-    if (!serviceAccount && !serverKey) {
-        return res.status(500).json({ error: 'FCM credentials not configured' });
+    if (!serverKey) {
+        return res.status(500).json({ error: 'FCM_SERVER_KEY not configured' });
     }
 
     try {
-        let response;
-
-        if (serviceAccount && projectId) {
-            // Preferir la API HTTP v1 si se proporciona una cuenta de servicio
-            const credentials = JSON.parse(serviceAccount);
-            const auth = new GoogleAuth({
-                credentials,
-                scopes: ['https://www.googleapis.com/auth/firebase.messaging']
-            });
-            const client = await auth.getClient();
-            const accessToken = await client.getAccessToken();
-
-            response = await fetch(
-                `https://fcm.googleapis.com/v1/projects/${projectId}/messages:send`,
-                {
-                    method: 'POST',
-                    headers: {
-                        Authorization: `Bearer ${accessToken.token || accessToken}`,
-                        'Content-Type': 'application/json'
-                    },
-                    body: JSON.stringify({
-                        message: {
-                            token,
-                            notification: {
-                                title,
-                                body,
-                                icon: '/images/icon-192.png'
-                            },
-                            data: extraData
-                        }
-                    })
-                }
-            );
-        } else {
-            // Uso de la API legacy con la clave del servidor
-            response = await fetch('https://fcm.googleapis.com/fcm/send', {
-                method: 'POST',
-                headers: {
-                    Authorization: `key=${serverKey}`,
-                    'Content-Type': 'application/json'
+        const response = await fetch('https://fcm.googleapis.com/fcm/send', {
+            method: 'POST',
+            headers: {
+                Authorization: `key=${serverKey}`,
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({
+                to: token,
+                notification: {
+                    title,
+                    body,
+                    icon: '/images/icon-192.png'
                 },
-                body: JSON.stringify({
-                    to: token,
-                    notification: {
-                        title,
-                        body,
-                        icon: '/images/icon-192.png'
-                    },
-                    data: extraData
-                })
-            });
-        }
+                data: extraData
+            })
+        });
 
         const text = await response.text();
         let responseData;


### PR DESCRIPTION
## Summary
- remove v1 FCM logic and service account handling
- send push notifications using legacy FCM API only

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6842cee59514832dbf6abc6909d3f05e