### PR TITLE
Fix FCM payload for HTTP v1

### DIFF
--- a/server.js
+++ b/server.js
@@ -64,8 +64,13 @@ app.post(['/api/send-notification', '/send-notification'], async (req, res) => {
                             token,
                             notification: {
                                 title,
-                                body,
-                                icon: '/images/icon-192.png'
+                                body
+                            },
+                            webpush: {
+                                notification: {
+                                    icon: '/images/icon-192.png',
+                                    badge: '/images/icon-72x72.png'
+                                }
                             },
                             data: extraData
                         }


### PR DESCRIPTION
## Summary
- fix invalid HTTP v1 FCM payload by moving icon under `webpush.notification`

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6842d6aba2d0832d9fabd1342c76febb