### PR TITLE
Clear FCM token on logout

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -48,7 +48,7 @@ import { auth } from './modules/firebase.js'; // Esto lo importa de forma limpia
 import { state } from './modules/state.js';
 import { startAuthListener, setUserLanguage } from './modules/auth.js';
 
-import { initializeNotifications } from './modules/notificaciones.js';
+import { initializeNotifications, eliminarTokenUsuario } from './modules/notificaciones.js';
 
 import {
     getUserLanguage,
@@ -2171,13 +2171,19 @@ function hideTypingIndicator() {
 // Eventos para enviar mensajes
 sendMessageBtn.addEventListener('click', (e) => {
     createRipple(e);
-    console.log('Botón enviar clickeado');
-    sendMessage(messageInput.value);
-});
+async function handleLogout() {
+    try {
+        const user = getCurrentUser();
 
-messageInput.addEventListener('input', () => {
-    handleTyping();
-});
+        if (user) {
+            await eliminarTokenUsuario(user.uid);
+        }
+
+        // Cancelar todas las suscripciones antes de cerrar sesión
+        if (unsubscribeChats) {
+            unsubscribeChats();
+            unsubscribeChats = null;
+        }
 
 messageInput.addEventListener('keypress', (e) => {
     if (e.key === 'Enter' && !e.shiftKey) {

--- a/public/app.js
+++ b/public/app.js
@@ -3284,9 +3284,6 @@ document.addEventListener('DOMContentLoaded', function() {
     }
 
 
-    // Volver desde ajustes
-    if (backFromSettings) {
-        backFromSettings.addEventListener('click', function() {
             if (settingsPage && chatList) {
                 settingsPage.classList.add('hidden');
                 chatList.classList.remove('hidden');

--- a/public/modules/notificaciones.js
+++ b/public/modules/notificaciones.js
@@ -9,9 +9,11 @@ import {
     query,
     where,
     collection,
-    limit
+    limit,
+    updateDoc,
+    deleteField
 } from 'https://www.gstatic.com/firebasejs/10.7.1/firebase-firestore.js';
-import { getToken, onMessage } from 'https://www.gstatic.com/firebasejs/10.7.1/firebase-messaging.js';
+import { getToken, onMessage, deleteToken } from 'https://www.gstatic.com/firebasejs/10.7.1/firebase-messaging.js';
 
 function showForegroundToast(title, body) {
     if (typeof window.showToast === 'function') {
@@ -60,6 +62,29 @@ export async function guardarTokenUnico(userId, token) {
     } catch (err) {
         console.error('❌ Error al guardar token único:', err);
         throw err;
+    }
+}
+
+export async function eliminarTokenUsuario(userId) {
+    try {
+        if (!userId) return;
+
+        try {
+            await deleteToken(messaging);
+            console.log('🗑️ Token FCM local eliminado');
+        } catch (err) {
+            console.warn('⚠️ No se pudo eliminar el token local:', err);
+        }
+
+        await updateDoc(doc(db, 'users', userId), {
+            fcmToken: deleteField(),
+            notificationsEnabled: false,
+            lastTokenUpdate: serverTimestamp()
+        });
+
+        console.log('🗑️ Token FCM eliminado en Firestore');
+    } catch (err) {
+        console.error('❌ Error al eliminar token FCM:', err);
     }
 }
 


### PR DESCRIPTION
## Summary
- remove device token when signing out so each account manages its own token

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6842ebfc37d4832dbd105aef23a89d3d