### PR TITLE
Fix duplicate notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,3 +65,4 @@ Las contribuciones son bienvenidas. Por favor, abre un issue primero para discut
 
 - Se eliminó la duplicación de notificaciones push y se mejoró el manejo del estado de escritura para evitar parpadeos en la lista de chats.
 - Se ajustó el *service worker* para mostrar correctamente las notificaciones cuando la aplicación está en segundo plano.
+- Las notificaciones se envían ahora sólo con datos, evitando que FCM muestre alertas automáticas duplicadas.

--- a/functions/index.js
+++ b/functions/index.js
@@ -78,11 +78,9 @@ exports.sendMessageNotification = functions.firestore
                 try {
                     const notificationMessage = {
                         token: token,
-                        notification: {
-                            title: senderName,
-                            body: message.text
-                        },
                         data: {
+                            title: senderName,
+                            body: message.text,
                             chatId: chatId,
                             messageId: context.params.messageId,
                             type: 'new_message'
@@ -98,12 +96,6 @@ exports.sendMessageNotification = functions.firestore
                         webpush: {
                             headers: {
                                 Urgency: 'high'
-                            },
-                            notification: {
-                                icon: '/images/icon-192.png',
-                                badge: '/images/icon-72.png',
-                                vibrate: [200, 100, 200],
-                                requireInteraction: true
                             },
                             fcmOptions: {
                                 link: `/?chatId=${chatId}`

--- a/public/modules/notificaciones.js
+++ b/public/modules/notificaciones.js
@@ -140,22 +140,22 @@ export async function initializeNotifications() {
                 // Configurar listener para mensajes en primer plano
                 onMessage(messaging, (payload) => {
                     console.log('🔔 Mensaje recibido en primer plano:', payload);
-                    
+
                     if (Notification.permission === 'granted' && 'serviceWorker' in navigator) {
                         navigator.serviceWorker.ready.then(registration => {
-                            const notificationTitle = payload.notification.title;
+                            const notificationTitle = payload.notification?.title || payload.data?.title || 'TraduChat';
                             const notificationOptions = {
-                                body: payload.notification.body,
+                                body: payload.notification?.body || payload.data?.body || '',
                                 icon: '/images/icon-192.png',
                                 badge: '/images/icon-72x72.png',
                                 vibrate: [200, 100, 200],
-                                tag: 'new-message',
+                                tag: payload.data?.messageId || 'new-message',
                                 data: payload.data,
                                 requireInteraction: true
                             };
 
                             registration.showNotification(notificationTitle, notificationOptions);
-                            showForegroundToast(notificationTitle, payload.notification.body);
+                            showForegroundToast(notificationTitle, notificationOptions.body);
                         });
                     }
                 });

--- a/server.js
+++ b/server.js
@@ -62,17 +62,11 @@ app.post(['/api/send-notification', '/send-notification'], async (req, res) => {
                     body: JSON.stringify({
                         message: {
                             token,
-                            notification: {
+                            data: {
                                 title,
-                                body
-                            },
-                            webpush: {
-                                notification: {
-                                    icon: '/images/icon-192.png',
-                                    badge: '/images/icon-72x72.png'
-                                }
-                            },
-                            data: extraData
+                                body,
+                                ...extraData
+                            }
                         }
                     })
                 }
@@ -88,12 +82,11 @@ app.post(['/api/send-notification', '/send-notification'], async (req, res) => {
                 },
                 body: JSON.stringify({
                     to: token,
-                    notification: {
+                    data: {
                         title,
                         body,
-                        icon: '/images/icon-192.png'
-                    },
-                    data: extraData
+                        ...extraData
+                    }
                 })
             });
         }


### PR DESCRIPTION
## Summary
- deliver FCM messages without a `notification` payload to avoid duplicates
- show foreground notifications from data-only payloads
- document the change in README

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6845c770eff8832d8031eed31ba00d72