### PR TITLE
Fix duplicate notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,3 +65,4 @@ Las contribuciones son bienvenidas. Por favor, abre un issue primero para discut
 
 - Se eliminó la duplicación de notificaciones push y se mejoró el manejo del estado de escritura para evitar parpadeos en la lista de chats.
 - Se ajustó el *service worker* para mostrar correctamente las notificaciones cuando la aplicación está en segundo plano.
+- El service worker evita mostrar alertas duplicadas cuando FCM ya incluye un payload de notificación.

--- a/public/firebase-messaging-sw.js
+++ b/public/firebase-messaging-sw.js
@@ -42,11 +42,13 @@ messaging.onBackgroundMessage(async (payload) => {
     options: notificationOptions
   });
 
-  if (!shownMessages.has(msgId)) {
-    shownMessages.add(msgId);
-    const existing = await self.registration.getNotifications({ tag: msgId });
-    if (existing.length === 0) {
-      self.registration.showNotification(notificationTitle, notificationOptions);
+  if (!payload.notification) {
+    if (!shownMessages.has(msgId)) {
+      shownMessages.add(msgId);
+      const existing = await self.registration.getNotifications({ tag: msgId });
+      if (existing.length === 0) {
+        self.registration.showNotification(notificationTitle, notificationOptions);
+      }
     }
   }
 });

--- a/public/modules/notificaciones.js
+++ b/public/modules/notificaciones.js
@@ -140,22 +140,22 @@ export async function initializeNotifications() {
                 // Configurar listener para mensajes en primer plano
                 onMessage(messaging, (payload) => {
                     console.log('🔔 Mensaje recibido en primer plano:', payload);
-                    
+
                     if (Notification.permission === 'granted' && 'serviceWorker' in navigator) {
                         navigator.serviceWorker.ready.then(registration => {
-                            const notificationTitle = payload.notification.title;
+                            const notificationTitle = payload.notification?.title || payload.data?.title || 'TraduChat';
                             const notificationOptions = {
-                                body: payload.notification.body,
+                                body: payload.notification?.body || payload.data?.body || '',
                                 icon: '/images/icon-192.png',
                                 badge: '/images/icon-72x72.png',
                                 vibrate: [200, 100, 200],
-                                tag: 'new-message',
+                                tag: payload.data?.messageId || 'new-message',
                                 data: payload.data,
                                 requireInteraction: true
                             };
 
                             registration.showNotification(notificationTitle, notificationOptions);
-                            showForegroundToast(notificationTitle, payload.notification.body);
+                            showForegroundToast(notificationTitle, notificationOptions.body);
                         });
                     }
                 });


### PR DESCRIPTION
## Summary
- restore `notification` payloads so web clients receive messages while closed
- show background notifications only if FCM didn't already
- document duplicate prevention strategy

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6845c770eff8832d8031eed31ba00d72