### PR TITLE
Implement unique username handling

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -457,12 +457,7 @@ loginBtn.addEventListener('click', async () => {
             const userCredential = await signInWithEmailAndPassword(auth, email, password);
             console.log('Login exitoso:', userCredential.user.uid);
 
-            const userDocRef = doc(db, 'users', userCredential.user.uid);
-            await setDoc(userDocRef, {
-                email: email,
-                username: username,
-                lastLogin: serverTimestamp()
-            }, { merge: true });
+            await updateUserData(userCredential.user, username, false);
 
             return;
         } catch (loginError) {
@@ -3214,6 +3209,7 @@ document.addEventListener('DOMContentLoaded', function() {
     const settingsLanguage = document.getElementById('settingsLanguage');
     const settingsTheme = document.getElementById('settingsTheme');
     const settingsLogoutBtn = document.getElementById('settingsLogoutBtn');
+    const editUsernameBtn = document.getElementById('editUsernameBtn');
 
 
     // Función para actualizar los botones activos
@@ -3298,6 +3294,29 @@ document.addEventListener('DOMContentLoaded', function() {
                 updateActiveButtons('btnChats');
                 currentListType = 'individual';
                 setupRealtimeChats(chatList, 'individual');
+            }
+        });
+    }
+
+    if (editUsernameBtn && settingsUsername) {
+        editUsernameBtn.addEventListener('click', async function() {
+            if (settingsUsername.hasAttribute('readonly')) {
+                settingsUsername.removeAttribute('readonly');
+                settingsUsername.focus();
+                editUsernameBtn.textContent = getTranslation('save', getUserLanguage());
+            } else {
+                const newUsername = settingsUsername.value.trim();
+                const usernameRegex = /^[a-zA-Z0-9_-]{3,20}$/;
+                if (!usernameRegex.test(newUsername)) {
+                    showToast(getTranslation('errorUsernameChars', getUserLanguage()));
+                    return;
+                }
+                const currentUser = getCurrentUser();
+                if (currentUser) {
+                    await updateUserData(currentUser, newUsername, false);
+                    settingsUsername.setAttribute('readonly', true);
+                    editUsernameBtn.textContent = getTranslation('edit', getUserLanguage());
+                }
             }
         });
     }

--- a/public/index.html
+++ b/public/index.html
@@ -172,6 +172,7 @@
                     readonly
                     class="readonly-input"
                   />
+                  <button id="editUsernameBtn" class="edit-btn" data-translate="edit">Editar</button>
                 </div>
               </div>
             </div>

--- a/public/styles.css
+++ b/public/styles.css
@@ -2253,6 +2253,22 @@ select:focus-visible {
   border: none;
 }
 
+.edit-btn {
+  margin-top: 5px;
+  padding: 6px 12px;
+  background: var(--color-primary);
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 0.8rem;
+}
+
+.edit-btn:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
 .app-version {
   font-size: 0.9rem;
   color: var(--color-text);

--- a/public/translations.js
+++ b/public/translations.js
@@ -109,6 +109,8 @@ const translations = {
         theme: 'Tema',
         about: 'Acerca de',
         developer: 'Desarrollado por Andrea Panepinto',
+        edit: 'Editar',
+        save: 'Guardar',
     },
     en: {
         // Authentication
@@ -218,6 +220,8 @@ const translations = {
         theme: 'Theme',
         about: 'About',
         developer: 'Developed by Andrea Panepinto',
+        edit: 'Edit',
+        save: 'Save',
     },
     it: {
         // Autenticazione
@@ -325,6 +329,8 @@ const translations = {
         theme: 'Tema',
         about: 'Informazioni',
         developer: 'Sviluppato da Andrea Panepinto',
+        edit: 'Modifica',
+        save: 'Salva',
     }
 };
 


### PR DESCRIPTION
## Summary
- disallow duplicate usernames on login by reusing `updateUserData`
- add edit button in settings to change username with validation
- translate Edit and Save labels
- style edit button

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68467c7ba1fc832db9ced68c7c1f4d30