### PR TITLE
Implement unique username system

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -166,12 +166,22 @@
                 <i class="fas fa-user"></i>
                 <div class="settings-item-content">
                   <label data-translate="username">Nombre de usuario</label>
-                  <input
-                    type="text"
-                    id="settingsUsername"
-                    readonly
-                    class="readonly-input"
-                  />
+                  <div class="settings-input-wrap">
+                    <input
+                      type="text"
+                      id="settingsUsername"
+                      readonly
+                      class="readonly-input"
+                    />
+                    <button
+                      id="editUsernameBtn"
+                      class="icon-button settings-edit-btn"
+                      aria-label="Editar"
+                      title="Editar"
+                    >
+                      <i class="fas fa-edit"></i>
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>

--- a/public/styles.css
+++ b/public/styles.css
@@ -2253,6 +2253,17 @@ select:focus-visible {
   border: none;
 }
 
+.settings-input-wrap {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.settings-edit-btn {
+  width: 32px;
+  height: 32px;
+}
+
 .app-version {
   font-size: 0.9rem;
   color: var(--color-text);

--- a/public/translations.js
+++ b/public/translations.js
@@ -26,6 +26,8 @@ const translations = {
         errorInvalidEmail: 'Email inválido',
         errorEmailInUse: 'Este email ya está registrado',
         errorUsernameInUse: 'Este nombre de usuario ya está en uso',
+        errorUsernameChange: 'No se puede usar ese nombre de usuario',
+        usernameUpdated: 'Nombre de usuario actualizado',
         errorNetwork: 'Error de conexión. Verifica tu conexión a internet',
         errorGeneric: 'Ha ocurrido un error',
         errorSendingCode: 'Error al enviar el código: {0}',
@@ -109,6 +111,8 @@ const translations = {
         theme: 'Tema',
         about: 'Acerca de',
         developer: 'Desarrollado por Andrea Panepinto',
+        edit: 'Editar',
+        save: 'Guardar',
     },
     en: {
         // Authentication
@@ -133,6 +137,8 @@ const translations = {
         errorInvalidEmail: 'Invalid email',
         errorEmailInUse: 'This email is already registered',
         errorUsernameInUse: 'This username is already taken',
+        errorUsernameChange: 'Cannot use that username',
+        usernameUpdated: 'Username updated',
         errorNetwork: 'Connection error. Check your internet connection',
         errorGeneric: 'An error has occurred',
         errorSendingCode: 'Error sending code: {0}',
@@ -218,6 +224,8 @@ const translations = {
         theme: 'Theme',
         about: 'About',
         developer: 'Developed by Andrea Panepinto',
+        edit: 'Edit',
+        save: 'Save',
     },
     it: {
         // Autenticazione
@@ -242,6 +250,9 @@ const translations = {
         errorPassword: 'La password deve contenere almeno 6 caratteri',
         errorInvalidEmail: 'Email non valida',
         errorEmailInUse: 'Questa email è già registrata',
+        errorUsernameInUse: 'Questo nome utente è già in uso',
+        errorUsernameChange: 'Non puoi usare quel nome utente',
+        usernameUpdated: 'Nome utente aggiornato',
         errorNetwork: 'Errore di connessione. Verifica la tua connessione internet',
         errorGeneric: 'Si è verificato un errore',
         errorSendingCode: 'Errore nell\'invio del codice: {0}',
@@ -325,6 +336,8 @@ const translations = {
         theme: 'Tema',
         about: 'Informazioni',
         developer: 'Sviluppato da Andrea Panepinto',
+        edit: 'Modifica',
+        save: 'Salva',
     }
 };
 


### PR DESCRIPTION
## Summary
- add translations for username update notifications
- enforce uniqueness in `updateUserData`
- add login check for username conflicts
- allow editing username from settings and handle updates
- add button in settings to edit username easily

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684681139c94832d88322f73e972ebbe