### PR TITLE
fix duplicate push notifications

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -78,11 +78,9 @@ exports.sendMessageNotification = functions.firestore
                 try {
                     const notificationMessage = {
                         token: token,
-                        notification: {
-                            title: senderName,
-                            body: message.text
-                        },
                         data: {
+                            title: senderName,
+                            body: message.text,
                             chatId: chatId,
                             messageId: context.params.messageId,
                             type: 'new_message'

--- a/server.js
+++ b/server.js
@@ -62,17 +62,17 @@ app.post(['/api/send-notification', '/send-notification'], async (req, res) => {
                     body: JSON.stringify({
                         message: {
                             token,
-                            notification: {
+                            data: {
                                 title,
-                                body
+                                body,
+                                ...extraData
                             },
                             webpush: {
                                 notification: {
                                     icon: '/images/icon-192.png',
                                     badge: '/images/icon-72x72.png'
                                 }
-                            },
-                            data: extraData
+                            }
                         }
                     })
                 }
@@ -88,12 +88,12 @@ app.post(['/api/send-notification', '/send-notification'], async (req, res) => {
                 },
                 body: JSON.stringify({
                     to: token,
-                    notification: {
+                    data: {
                         title,
                         body,
-                        icon: '/images/icon-192.png'
-                    },
-                    data: extraData
+                        icon: '/images/icon-192.png',
+                        ...extraData
+                    }
                 })
             });
         }


### PR DESCRIPTION
## Summary
- send FCM push notifications as data-only messages on the server and on Cloud Functions

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm start` *(fails: Cannot find package 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68468f6d0950832daf4819ef9cc89def