### PR TITLE
Fix duplicate notification by using data-only messages

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -77,32 +77,15 @@ exports.sendMessageNotification = functions.firestore
             const results = await Promise.all(tokens.map(async (token) => {
                 try {
                     const notificationMessage = {
-                        token: token,
+                        token,
                         data: {
                             title: senderName,
                             body: message.text,
-                            chatId: chatId,
+                            chatId,
                             messageId: context.params.messageId,
                             type: 'new_message'
                         },
-                        android: {
-                            priority: 'high',
-                            notification: {
-                                clickAction: 'FLUTTER_NOTIFICATION_CLICK',
-                                priority: 'high',
-                                sound: 'default'
-                            }
-                        },
                         webpush: {
-                            headers: {
-                                Urgency: 'high'
-                            },
-                            notification: {
-                                icon: '/images/icon-192.png',
-                                badge: '/images/icon-72.png',
-                                vibrate: [200, 100, 200],
-                                requireInteraction: true
-                            },
                             fcmOptions: {
                                 link: `/?chatId=${chatId}`
                             }

--- a/server.js
+++ b/server.js
@@ -68,9 +68,8 @@ app.post(['/api/send-notification', '/send-notification'], async (req, res) => {
                                 ...extraData
                             },
                             webpush: {
-                                notification: {
-                                    icon: '/images/icon-192.png',
-                                    badge: '/images/icon-72x72.png'
+                                fcmOptions: {
+                                    link: extraData?.chatId ? `/?chatId=${extraData.chatId}` : '/'
                                 }
                             }
                         }
@@ -91,7 +90,6 @@ app.post(['/api/send-notification', '/send-notification'], async (req, res) => {
                     data: {
                         title,
                         body,
-                        icon: '/images/icon-192.png',
                         ...extraData
                     }
                 })


### PR DESCRIPTION
## Summary
- send push notifications without the `notification` field
- remove Android and webpush.notification options so service worker handles display

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684693ca6ec0832dafec1523270efce8