### PR TITLE
Fix chat load when opening from notification

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -2236,7 +2236,9 @@ window.addEventListener('load', () => {
     if (savedUser) {
         currentUser = JSON.parse(savedUser);
         showMainScreen();
-        handleChatFromUrl();
+        // ⚠️ No abrimos el chat aún. Esperamos a que Firebase
+        // restaure la autenticación real para evitar errores de
+        // permisos al cargar mensajes.
     }
 });
 


### PR DESCRIPTION
## Summary
- avoid opening chats before Firebase auth is restored

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6847bbb1b67c832d9afc46f2c7cdaaee