### PR TITLE
Fix chat load when opened from notification

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -77,7 +77,11 @@ startAuthListener(async (userData) => {
         showMainScreen();
         updateUserInfo(userData);
         setupRealtimeChats(chatList, 'individual');
-        handleChatFromUrl();
+        if (pendingChatId && !chatFromUrlHandled) {
+            openChat(pendingChatId);
+            chatFromUrlHandled = true;
+            pendingChatId = null;
+        }
         initializeNotifications(); // Aquí está bien colocada
     } else {
         console.log('No hay usuario autenticado');
@@ -156,6 +160,11 @@ let isGroupCreationMode = false;
 
 // Controla que solo se abra un chat por parámetro una vez
 let chatFromUrlHandled = false;
+let pendingChatId = null;
+
+// Detectar si hay un chat especificado en la URL lo antes posible
+const initialParams = new URLSearchParams(window.location.search);
+pendingChatId = initialParams.get('chatId');
 
 // Si se habilita, las notificaciones push se enviarán tanto
 // desde el cliente como desde las Cloud Functions, pudiendo
@@ -724,7 +733,11 @@ document.addEventListener('DOMContentLoaded', () => {
                 if (languageSelectMain) languageSelectMain.value = lang;
 
                 showMainScreen();
-                handleChatFromUrl();
+                if (pendingChatId && !chatFromUrlHandled && auth.currentUser) {
+                    openChat(pendingChatId);
+                    chatFromUrlHandled = true;
+                    pendingChatId = null;
+                }
             } catch (error) {
                 console.error('❌ Error cargando idioma:', error);
                 showError('errorGeneric');
@@ -887,10 +900,14 @@ function handleChatFromUrl() {
     if (chatFromUrlHandled) return;
     const params = new URLSearchParams(window.location.search);
     const chatId = params.get('chatId');
-    if (chatId) {
+    if (!chatId) return;
+
+    pendingChatId = chatId;
+
+    if (auth.currentUser) {
         openChat(chatId);
+        chatFromUrlHandled = true;
     }
-    chatFromUrlHandled = true;
 }
 
 // Función para limpiar el estado del chat
@@ -2236,7 +2253,6 @@ window.addEventListener('load', () => {
     if (savedUser) {
         currentUser = JSON.parse(savedUser);
         showMainScreen();
-        handleChatFromUrl();
     }
 });
 


### PR DESCRIPTION
## Summary
- detect chatId from URL on load
- stop relying on saved user for chat opening

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6847bbb1b67c832d9afc46f2c7cdaaee