### PR TITLE
Fix chat opening from notification

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -44,7 +44,7 @@ import { initializeApp } from 'https://www.gstatic.com/firebasejs/10.7.1/firebas
 import { translations, getTranslation, translateInterface, animateTitleWave, getTypingText, getTypingMessage } from './translations.js';
 import { translateText, getFlagEmoji, AVAILABLE_LANGUAGES } from './translation-service.js';
 
-import { auth } from './modules/firebase.js'; // Esto lo importa de forma limpia y segura
+import { auth, db } from './modules/firebase.js'; // Importamos también la instancia de Firestore
 import { state } from './modules/state.js';
 import { startAuthListener, setUserLanguage } from './modules/auth.js';
 


### PR DESCRIPTION
## Summary
- ensure Firestore instance is available by importing `db`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6847c526f798832db2e6e311991ce0a9