### PR TITLE
Improve notification redirect

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -34,6 +34,7 @@ exports.sendMessageNotification = functions.firestore
 
             const chatData = chatDoc.data();
             console.log('💬 Datos del chat:', chatData);
+            const chatType = chatData.type || 'individual';
 
             // Obtener los participantes del chat
             const participants = chatData.participants || [];
@@ -83,11 +84,12 @@ exports.sendMessageNotification = functions.firestore
                             body: message.text,
                             chatId,
                             messageId: context.params.messageId,
-                            type: 'new_message'
+                            type: 'new_message',
+                            chatType
                         },
                         webpush: {
                             fcmOptions: {
-                                link: `/?chatId=${chatId}`
+                                link: chatType === 'group' ? '/?view=groups' : '/'
                             }
                         }
                     };

--- a/public/app.js
+++ b/public/app.js
@@ -75,6 +75,7 @@ startAuthListener(async (userData) => {
         resetChatState();
         hideLoadingScreen();
         showMainScreen();
+        handleViewFromUrl();
         updateUserInfo(userData);
         setupRealtimeChats(chatList, 'individual');
         if (pendingChatId && !chatFromUrlHandled) {
@@ -907,6 +908,21 @@ function handleChatFromUrl() {
     if (auth.currentUser) {
         openChat(chatId);
         chatFromUrlHandled = true;
+    }
+}
+
+// Muestra la lista de grupos si la URL incluye ?view=groups
+function handleViewFromUrl() {
+    const params = new URLSearchParams(window.location.search);
+    const view = params.get('view');
+    if (view === 'groups' && groupsPage && chatList) {
+        groupsPage.classList.add('active');
+        chatList.classList.add('hidden');
+        if (settingsPage) settingsPage.classList.add('hidden');
+        document.querySelectorAll('.nav-button').forEach(btn => btn.classList.remove('active'));
+        document.querySelectorAll('#btnGroups').forEach(btn => btn.classList.add('active'));
+        currentListType = 'group';
+        setupRealtimeChats(groupsListEl, 'group');
     }
 }
 
@@ -3406,6 +3422,9 @@ document.addEventListener('DOMContentLoaded', function() {
     document.getElementById('createGroupFromGroups').addEventListener('click', () => {
         showGroupCreationModal();
     });
+
+    // Aplicar vista inicial según la URL
+    handleViewFromUrl();
 });
 
 

--- a/public/firebase-messaging-sw.js
+++ b/public/firebase-messaging-sw.js
@@ -57,8 +57,12 @@ self.addEventListener('notificationclick', (event) => {
 
   event.notification.close();
 
-  // Navegar a la aplicación raíz al hacer clic en la notificación
-  const urlToOpen = new URL('/', self.location.origin).href;
+  const data = event.notification.data || {};
+  let urlPath = '/';
+  if (data.chatType === 'group') {
+    urlPath = '/?view=groups';
+  }
+  const urlToOpen = new URL(urlPath, self.location.origin).href;
 
   event.waitUntil(
     clients.matchAll({ type: 'window', includeUncontrolled: true })


### PR DESCRIPTION
## Summary
- send chat type in Cloud Function notifications
- support `view=groups` parameter to open the groups list
- when launching from a notification, open group or individual lists accordingly

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6847cf2fdd0c832d817ba528081a5707