### PR TITLE
Add wave height variable and customizable title animation

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -978,6 +978,7 @@ body {
   color: var(--color-primary-dark);
   font-weight: 700;
   text-shadow: 0 2px 18px rgba(30, 233, 142, 0.27);
+  --wave-height: 10px;
 }
 
 #titulo-wave span {
@@ -1247,7 +1248,7 @@ body {
     transform: translateY(0);
   }
   30% {
-    transform: translateY(-10px);
+    transform: translateY(calc(var(--wave-height, 10px) * -1));
   }
 }
 
@@ -1293,6 +1294,7 @@ body {
 
   #titulo-wave {
     font-size: 1.8rem;
+    --wave-height: 8px;
   }
 
   .auth-container {

--- a/public/translations.js
+++ b/public/translations.js
@@ -400,7 +400,7 @@ function translateInterface(language) {
     console.log('✅ Traducción de interfaz completada');
 }
 
-function animateTitleWave() {
+function animateTitleWave({ colors = [], heights = [] } = {}) {
     const h1 = document.getElementById("titulo-wave");
     if (h1) {
         const text = h1.textContent;
@@ -409,6 +409,12 @@ function animateTitleWave() {
             const span = document.createElement("span");
             span.textContent = char === ' ' ? '\u00A0' : char;
             span.style.setProperty('--i', i);
+            if (colors[i]) {
+                span.style.color = colors[i];
+            }
+            if (heights[i]) {
+                span.style.setProperty('--wave-height', heights[i]);
+            }
             h1.appendChild(span);
         });
     }


### PR DESCRIPTION
## Summary
- support a `--wave-height` property on the waving title
- adjust small-screen styles
- allow `animateTitleWave()` to apply per-letter colors and heights

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68484a0034b8832dae554dd543217e1c