### PR TITLE
Add profile picture support

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -163,6 +163,25 @@
             <div class="settings-section">
               <h3 data-translate="profile">Perfil</h3>
               <div class="settings-item">
+                <i class="fas fa-image"></i>
+                <div class="settings-item-content">
+                  <label data-translate="profileImage">Foto de perfil</label>
+                  <div class="avatar-input-wrap">
+                    <div id="avatarDisplay" class="avatar-placeholder"></div>
+                    <img id="profileAvatar" class="avatar hidden" alt="Avatar" />
+                    <input type="file" id="avatarInput" accept="image/*" class="hidden" />
+                    <button
+                      id="changeAvatarBtn"
+                      class="icon-button settings-edit-btn"
+                      aria-label="Editar"
+                      title="Editar"
+                    >
+                      <i class="fas fa-edit"></i>
+                    </button>
+                  </div>
+                </div>
+              </div>
+              <div class="settings-item">
                 <i class="fas fa-user"></i>
                 <div class="settings-item-content">
                   <label data-translate="username">Nombre de usuario</label>

--- a/public/styles.css
+++ b/public/styles.css
@@ -501,6 +501,17 @@ body {
   flex: 1;
   min-width: 0;
   overflow: hidden;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.chat-header-name {
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex: 1;
 }
 
 /* Información del chat grupal */
@@ -558,6 +569,39 @@ body {
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.04);
   position: relative;
   padding-right: 40px;
+}
+
+.chat-avatar {
+  width: 40px;
+  height: 40px;
+  margin-right: 12px;
+  flex-shrink: 0;
+}
+
+.avatar {
+  width: 100%;
+  height: 100%;
+  border-radius: 8px;
+  object-fit: cover;
+}
+
+.avatar-placeholder {
+  width: 100%;
+  height: 100%;
+  border-radius: 8px;
+  background: var(--color-primary);
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: bold;
+  text-transform: uppercase;
+}
+
+.avatar-input-wrap {
+  display: flex;
+  align-items: center;
+  gap: 8px;
 }
 
 .chat-item:hover {

--- a/public/translations.js
+++ b/public/translations.js
@@ -113,6 +113,8 @@ const translations = {
         developer: 'Desarrollado por Andrea Panepinto',
         edit: 'Editar',
         save: 'Guardar',
+        profileImage: 'Foto de perfil',
+        avatarUpdated: 'Foto de perfil actualizada',
     },
     en: {
         // Authentication
@@ -226,6 +228,8 @@ const translations = {
         developer: 'Developed by Andrea Panepinto',
         edit: 'Edit',
         save: 'Save',
+        profileImage: 'Profile picture',
+        avatarUpdated: 'Profile picture updated',
     },
     it: {
         // Autenticazione
@@ -338,6 +342,8 @@ const translations = {
         developer: 'Sviluppato da Andrea Panepinto',
         edit: 'Modifica',
         save: 'Salva',
+        profileImage: 'Foto profilo',
+        avatarUpdated: 'Foto profilo aggiornata',
     }
 };
 

--- a/storage.rules
+++ b/storage.rules
@@ -9,9 +9,17 @@ service firebase.storage {
     // Reglas para archivos de audio
     match /audios/{chatId}/{fileName} {
       allow read: if isAuthenticated();
-      allow write: if isAuthenticated() 
+      allow write: if isAuthenticated()
         && request.resource.contentType.matches('audio/.*')
         && request.resource.size < 10 * 1024 * 1024; // Máximo 10MB
     }
+
+    match /avatars/{userId}/{fileName} {
+      allow read: if isAuthenticated();
+      allow write: if isAuthenticated()
+        && request.auth.uid == userId
+        && request.resource.contentType.matches('image/.*')
+        && request.resource.size < 5 * 1024 * 1024; // Máximo 5MB
+    }
   }
-} 
+}


### PR DESCRIPTION
## Summary
- allow users to upload a profile picture from settings
- display avatar placeholders when no image is present
- show avatar next to chat names and in chat header
- update Firestore storage rules for avatar uploads
- include new translation strings

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684bc8e4fdfc832d9c85224787d95c97