### PR TITLE
Add CORS instructions for Firebase Storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,33 @@ innecesarias a la API y así ahorrar tiempo y créditos.
    la clave de servidor (**FCM_SERVER_KEY**) o definir **FIREBASE_PROJECT_ID**,
    **FIREBASE_CLIENT_EMAIL** y **FIREBASE_PRIVATE_KEY** para utilizar la API HTTP v1.
 
+### Configurar CORS en Firebase Storage
+
+Si la aplicación se ejecuta desde un dominio distinto a `firebaseapp.com`, es
+necesario habilitar CORS en el bucket de Storage para permitir la subida de
+archivos desde el navegador. En este repositorio se incluye el archivo
+`storage-cors.json` con una configuración de ejemplo:
+
+```json
+[
+  {
+    "origin": ["https://traduchat.vercel.app"],
+    "method": ["GET", "HEAD", "PUT", "POST", "DELETE"],
+    "responseHeader": ["Authorization"],
+    "maxAgeSeconds": 3600
+  }
+]
+```
+
+Aplica la configuración ejecutando:
+
+```bash
+gsutil cors set storage-cors.json gs://traduchat-2.appspot.com
+```
+
+Esto permitirá que las peticiones a Firebase Storage desde la web superen la
+verificación CORS del navegador.
+
 ## Compatibilidad
 
 Desde iOS 16.4, Safari y las PWA instaladas permiten recibir notificaciones push

--- a/storage-cors.json
+++ b/storage-cors.json
@@ -1,0 +1,8 @@
+[
+  {
+    "origin": ["https://traduchat.vercel.app"],
+    "method": ["GET", "HEAD", "PUT", "POST", "DELETE"],
+    "responseHeader": ["Authorization"],
+    "maxAgeSeconds": 3600
+  }
+]


### PR DESCRIPTION
## Summary
- document how to enable CORS for Firebase Storage
- add example `storage-cors.json` file

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684bd4062e48832d8ac3d512555e0741