### PR TITLE
Fix Firebase Storage bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ archivos desde el navegador. En este repositorio se incluye el archivo
 Aplica la configuración ejecutando:
 
 ```bash
-gsutil cors set storage-cors.json gs://traduchat-2.appspot.com
+gsutil cors set storage-cors.json gs://traduchat-2.firebasestorage.app
 ```
 
 Esto permitirá que las peticiones a Firebase Storage desde la web superen la

--- a/public/firebase-messaging-sw.js
+++ b/public/firebase-messaging-sw.js
@@ -5,7 +5,7 @@ const firebaseConfig = {
   apiKey: "AIzaSyBPurWNRib5yjg-jEe3x2hBewL_Cvy132E",
   authDomain: "traduchat-2.firebaseapp.com",
   projectId: "traduchat-2",
-  storageBucket: "traduchat-2.appspot.com",
+  storageBucket: "traduchat-2.firebasestorage.app",
   messagingSenderId: "304746474467",
   appId: "1:304746474467:web:a0496a8d1d891cec170ed6"
 };

--- a/public/index.html
+++ b/public/index.html
@@ -400,7 +400,7 @@
         apiKey: "AIzaSyBPurWNRib5yjg-jEe3x2hBewL_Cvy132E",
         authDomain: "traduchat-2.firebaseapp.com",
         projectId: "traduchat-2",
-        storageBucket: "traduchat-2.appspot.com",
+        storageBucket: "traduchat-2.firebasestorage.app",
         messagingSenderId: "304746474467",
         appId: "1:304746474467:web:a0496a8d1d891cec170ed6",
       };

--- a/public/modules/firebase-config.js
+++ b/public/modules/firebase-config.js
@@ -6,7 +6,7 @@ export const firebaseConfig = {
     authDomain: "traduchat-2.firebaseapp.com",
     databaseURL: "https://traduchat-2-default-rtdb.europe-west1.firebasedatabase.app",
     projectId: "traduchat-2",
-    storageBucket: "traduchat-2.appspot.com",
+    storageBucket: "traduchat-2.firebasestorage.app",
     messagingSenderId: "304746474467",
     appId: "1:304746474467:web:a0496a8d1d891cec170ed6"
 };

--- a/public/modules/firebase.js
+++ b/public/modules/firebase.js
@@ -23,6 +23,6 @@ setPersistence(auth, browserLocalPersistence);
 
 const db = getFirestore(app);
 const messaging = getMessaging(app);
-const storage = getStorage(app);
+const storage = getStorage(app, "gs://traduchat-2.firebasestorage.app");
 
 export { app, auth, db, messaging, storage };


### PR DESCRIPTION
## Summary
- update Firebase storage bucket URL to use `traduchat-2.firebasestorage.app`
- pass bucket explicitly to `getStorage`
- update README with new bucket instructions

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684d1eaffcbc832dbea5da9b56ea82f8