### PR TITLE
Reduce iOS safe-area spacing

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -548,8 +548,8 @@ body {
   background-color: #fff;
   -webkit-overflow-scrolling: touch;
   padding: 10px;
-  padding-bottom: calc(120px + env(safe-area-inset-bottom, 0px));
-  height: calc(100vh - var(--header-height) - env(safe-area-inset-bottom, 0px));
+  padding-bottom: calc(120px + var(--safe-area-bottom));
+  height: calc(100vh - var(--header-height) - var(--safe-area-bottom));
   position: relative;
   z-index: 1;
   scrollbar-width: thin;
@@ -973,7 +973,7 @@ body {
 
   .messages-list {
     padding-bottom: calc(
-      var(--message-input-height) + env(safe-area-inset-bottom)
+      var(--message-input-height) + var(--safe-area-bottom)
     );
   }
 
@@ -991,7 +991,8 @@ body {
     screen and (device-width: 428px) and (device-height: 926px) and (-webkit-device-pixel-ratio: 3) {
     :root {
       --safe-area-top: env(safe-area-inset-top, 44px);
-      --safe-area-bottom: env(safe-area-inset-bottom, 34px);
+      /* Reduce spacing for the home indicator */
+      --safe-area-bottom: 20px;
     }
   }
 }
@@ -1963,7 +1964,8 @@ select:focus-visible {
     (device-width: 430px) and (device-height: 932px) and (-webkit-device-pixel-ratio: 3) {
     :root {
       --safe-area-top: env(safe-area-inset-top, 47px);
-      --safe-area-bottom: env(safe-area-inset-bottom, 34px);
+      /* Reduce spacing for the home indicator */
+      --safe-area-bottom: 20px;
     }
 
     .user-header,
@@ -1976,7 +1978,7 @@ select:focus-visible {
     /* Ajustar contenido debajo del header */
     .chat-list {
       height: calc(100% - (var(--header-height) + env(safe-area-inset-top)));
-      padding-bottom: env(safe-area-inset-bottom);
+      padding-bottom: var(--safe-area-bottom);
     }
 
     .messages-list {
@@ -1984,7 +1986,7 @@ select:focus-visible {
         100% - (var(--header-height) + env(safe-area-inset-top)) -
           var(--message-input-height)
       );
-      padding-bottom: calc(env(safe-area-inset-bottom) + 10px);
+      padding-bottom: calc(var(--safe-area-bottom) + 10px);
     }
   }
 }
@@ -2170,7 +2172,7 @@ select:focus-visible {
   border-top: 1px solid var(--color-border);
   z-index: 600;
   overscroll-behavior-y: contain;
-  padding-bottom: env(safe-area-inset-bottom, 0px);
+  padding-bottom: var(--safe-area-bottom);
 }
 
 .nav-button {
@@ -2202,13 +2204,13 @@ select:focus-visible {
 /* Ajustes específicos para iOS */
 @supports (-webkit-touch-callout: none) {
   .bottom-nav {
-    height: calc(55px + env(safe-area-inset-bottom));
+    height: calc(55px + var(--safe-area-bottom));
     padding-bottom: max(10px, var(--safe-area-bottom));
   }
 
   .chat-list,
   .groups-list {
-    padding-bottom: calc(180px + env(safe-area-inset-bottom));
+    padding-bottom: calc(180px + var(--safe-area-bottom));
   }
 }
 
@@ -2260,7 +2262,7 @@ select:focus-visible {
   flex: 1;
   overflow-y: auto;
   padding: 20px 15px;
-  padding-bottom: calc(70px + env(safe-area-inset-bottom, 0px));
+  padding-bottom: calc(70px + var(--safe-area-bottom));
 }
 
 .settings-section {


### PR DESCRIPTION
## Summary
- lower the space reserved for the iOS home indicator
- update layout rules to rely on `--safe-area-bottom` variable

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68504482b494832d8c447b9c5d1ef820