### PR TITLE
Fix storage rule for group images

### DIFF
--- a/storage.rules
+++ b/storage.rules
@@ -21,5 +21,13 @@ service firebase.storage {
         && request.resource.contentType.matches('image/.*')
         && request.resource.size < 5 * 1024 * 1024; // Máximo 5MB
     }
+
+    // Reglas para avatares de grupos
+    match /groupAvatars/{groupId}/{fileName} {
+      allow read: if isAuthenticated();
+      allow write: if isAuthenticated()
+        && request.resource.contentType.matches('image/.*')
+        && request.resource.size < 5 * 1024 * 1024; // Máximo 5MB
+    }
   }
 }


### PR DESCRIPTION
## Summary
- allow uploading group avatars in Firebase Storage

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685145dc7030832d8cba2ff9a0b24830