### PR TITLE
Add user chat subcollection rules

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -23,9 +23,9 @@ service cloud.firestore {
     match /chats/{chatId} {
       allow create: if isAuthenticated();
       allow read: if isAuthenticated();
-      allow update: if isAuthenticated() && 
-                   (resource == null || 
-                    resource.data.participants.hasAny([request.auth.uid]));
+      allow update: if isAuthenticated() &&
+                     (resource == null ||
+                      resource.data.participants.hasAny([request.auth.uid]));
       // Cambiar esta línea para permitir borrado a participantes
       allow delete: if isAuthenticated() && 
                    resource.data.participants.hasAny([request.auth.uid]);
@@ -52,6 +52,12 @@ service cloud.firestore {
                            get(/databases/$(database)/documents/chats/$(chatId))
                            .data.participants.hasAny([request.auth.uid]);
       }
+    }
+
+    // Reglas para los chats de cada usuario
+    match /userChats/{userId}/chats/{chatId} {
+      allow read, write: if request.auth != null &&
+                         request.auth.uid == userId;
     }
   }
 }


### PR DESCRIPTION
## Summary
- update Firestore security rules so each user can only access their own `userChats/{userId}/chats` documents

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68514deeb820832d8a5dc33b51aa1a37