### PR TITLE
Enhance settings edit buttons

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -674,8 +674,9 @@ function showGroupAvatarPreview() {
                 <div class="modal-content avatar-modal-content">
                     ${content}
                     <input type="file" id="groupAvatarChange" class="hidden" accept="image/*" />
-                    <button id="editGroupAvatar" class="icon-button settings-edit-btn" aria-label="${getTranslation('edit', getUserLanguage())}">
+                    <button id="editGroupAvatar" class="settings-edit-btn" aria-label="${getTranslation('edit', getUserLanguage())}">
                         <i class="fas fa-edit"></i>
+                        <span>${getTranslation('edit', getUserLanguage())}</span>
                     </button>
                 </div>
             </div>`;
@@ -2699,7 +2700,10 @@ function showGroupCreationModal() {
                             <div id="groupAvatarDisplay" class="avatar-placeholder"></div>
                             <img id="groupAvatarPreview" class="avatar hidden" alt="Avatar" />
                             <input type="file" id="groupAvatarInput" accept="image/*" class="hidden" />
-                            <button id="changeGroupAvatarBtn" class="icon-button settings-edit-btn" aria-label="${getTranslation('edit', userLanguage)}" title="${getTranslation('edit', userLanguage)}"><i class="fas fa-edit"></i></button>
+                            <button id="changeGroupAvatarBtn" class="settings-edit-btn" aria-label="${getTranslation('edit', userLanguage)}" title="${getTranslation('edit', userLanguage)}">
+                                <i class="fas fa-edit"></i>
+                                <span>${getTranslation('edit', userLanguage)}</span>
+                            </button>
                         </div>
                     </div>
                     <input type="text" id="groupName" data-translate="groupNamePlaceholder" placeholder="${getTranslation('groupNamePlaceholder', userLanguage)}" />
@@ -3455,8 +3459,8 @@ document.addEventListener('DOMContentLoaded', function() {
             settingsUsername.removeAttribute('readonly');
             settingsUsername.classList.remove('readonly-input');
             settingsUsername.focus();
-            editUsernameBtn.innerHTML = '<i class="fas fa-check"></i>';
             const label = getTranslation('save', getUserLanguage());
+            editUsernameBtn.innerHTML = `<i class="fas fa-check"></i> <span>${label}</span>`;
             editUsernameBtn.setAttribute('aria-label', label);
             editUsernameBtn.setAttribute('title', label);
         }
@@ -3479,8 +3483,8 @@ document.addEventListener('DOMContentLoaded', function() {
             if (!settingsUsername.hasAttribute('readonly')) {
                 settingsUsername.classList.add('readonly-input');
                 settingsUsername.setAttribute('readonly', true);
-                editUsernameBtn.innerHTML = '<i class="fas fa-edit"></i>';
                 const label = getTranslation('edit', getUserLanguage());
+                editUsernameBtn.innerHTML = `<i class="fas fa-edit"></i> <span>${label}</span>`;
                 editUsernameBtn.setAttribute('aria-label', label);
                 editUsernameBtn.setAttribute('title', label);
                 if (settingsUsername.value.trim() !== original) {
@@ -3589,7 +3593,7 @@ document.addEventListener('DOMContentLoaded', function() {
                     const label = getTranslation('edit', getUserLanguage());
                     editUsernameBtn.setAttribute('aria-label', label);
                     editUsernameBtn.setAttribute('title', label);
-                    editUsernameBtn.innerHTML = '<i class="fas fa-edit"></i>';
+                    editUsernameBtn.innerHTML = `<i class="fas fa-edit"></i> <span>${label}</span>`;
                 }
             }
         });

--- a/public/index.html
+++ b/public/index.html
@@ -172,11 +172,12 @@
                     <input type="file" id="avatarInput" accept="image/*" class="hidden" />
                     <button
                       id="changeAvatarBtn"
-                      class="icon-button settings-edit-btn"
+                      class="settings-edit-btn"
                       aria-label="Editar"
                       title="Editar"
                     >
                       <i class="fas fa-edit"></i>
+                      <span data-translate="edit">Editar</span>
                     </button>
                   </div>
                 </div>
@@ -194,11 +195,12 @@
                     />
                     <button
                       id="editUsernameBtn"
-                      class="icon-button settings-edit-btn"
+                      class="settings-edit-btn"
                       aria-label="Editar"
                       title="Editar"
                     >
                       <i class="fas fa-edit"></i>
+                      <span data-translate="edit">Editar</span>
                     </button>
                   </div>
                 </div>

--- a/public/styles.css
+++ b/public/styles.css
@@ -2422,8 +2422,23 @@ select:focus-visible {
 }
 
 .settings-edit-btn {
-  width: 32px;
-  height: 32px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border-radius: 8px;
+  font-size: 0.9rem;
+  font-weight: 500;
+  background: var(--color-primary);
+  color: #fff;
+  border: none;
+  cursor: pointer;
+  transition: background-color 0.2s ease, transform 0.2s ease;
+}
+
+.settings-edit-btn:hover {
+  background: var(--color-primary-dark);
+  transform: scale(1.02);
 }
 
 .app-version {


### PR DESCRIPTION
## Summary
- improve `settings-edit-btn` style and hover effect
- show text on profile image and username edit buttons
- adjust related HTML and JS to use the new style

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6851523a6208832db2aa5228f52e856e