### PR TITLE
Improve edit buttons contrast

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -2426,6 +2426,11 @@ select:focus-visible {
   height: 32px;
 }
 
+/* Asegura contraste para los iconos dentro de los botones de edición */
+.settings-edit-btn i {
+  color: var(--color-text-light);
+}
+
 .app-version {
   font-size: 0.9rem;
   color: var(--color-text);


### PR DESCRIPTION
## Summary
- make edit icons visible across all themes by setting their color to `var(--color-text-light)`

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68515408b304832d9759c3e177ed7eca