### PR TITLE
Add camera capture option for avatars

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -673,7 +673,7 @@ function showGroupAvatarPreview() {
             <div id="groupAvatarModal" class="modal">
                 <div class="modal-content avatar-modal-content">
                     ${content}
-                    <input type="file" id="groupAvatarChange" class="hidden" accept="image/*" />
+                    <input type="file" id="groupAvatarChange" class="hidden" accept="image/*" capture="environment" />
                     <button id="editGroupAvatar" class="icon-button settings-edit-btn" aria-label="${getTranslation('edit', getUserLanguage())}">
                         <i class="fas fa-edit"></i>
                     </button>
@@ -2698,7 +2698,7 @@ function showGroupCreationModal() {
                         <div class="avatar-input-wrap">
                             <div id="groupAvatarDisplay" class="avatar-placeholder"></div>
                             <img id="groupAvatarPreview" class="avatar hidden" alt="Avatar" />
-                            <input type="file" id="groupAvatarInput" accept="image/*" class="hidden" />
+                            <input type="file" id="groupAvatarInput" accept="image/*" capture="environment" class="hidden" />
                             <button id="changeGroupAvatarBtn" class="icon-button settings-edit-btn" aria-label="${getTranslation('edit', userLanguage)}" title="${getTranslation('edit', userLanguage)}"><i class="fas fa-edit"></i></button>
                         </div>
                     </div>

--- a/public/index.html
+++ b/public/index.html
@@ -169,7 +169,7 @@
                   <div class="avatar-input-wrap">
                     <div id="avatarDisplay" class="avatar-placeholder"></div>
                     <img id="profileAvatar" class="avatar hidden" alt="Avatar" />
-                    <input type="file" id="avatarInput" accept="image/*" class="hidden" />
+                    <input type="file" id="avatarInput" accept="image/*" capture="environment" class="hidden" />
                     <button
                       id="changeAvatarBtn"
                       class="icon-button settings-edit-btn"


### PR DESCRIPTION
## Summary
- allow taking photos directly from the device camera by enabling the `capture` attribute on file inputs

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68515ef75bc4832d90140a2cca7f2eb6