### PR TITLE
Add sliding transition when opening or closing chats

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -2506,7 +2506,7 @@ function toggleChatList(show) {
         }
         if (chatContainer) {
             chatContainer.classList.remove('hidden');
-            chatContainer.style.display = 'block';
+            chatContainer.style.display = '';
         }
     }
 
@@ -2518,7 +2518,7 @@ function toggleChatList(show) {
         }
         if (chatContainer) {
             chatContainer.classList.add('hidden');
-            chatContainer.style.display = 'none';
+            chatContainer.style.display = '';
         }
         
         // Cancelar suscripción a mensajes si existe
@@ -2565,7 +2565,7 @@ function toggleChatList(show) {
         }
         if (chatContainer) {
             chatContainer.classList.remove('hidden');
-            chatContainer.style.display = 'block';
+            chatContainer.style.display = '';
         }
     }
 
@@ -2594,11 +2594,11 @@ window.addEventListener('resize', () => {
         }
         if (chatContainer) {
             chatContainer.classList.remove('hidden');
-            chatContainer.style.display = 'block';
+            chatContainer.style.display = '';
         }
         if (backButton) backButton.style.display = 'none';
     } else if (backButton) {
-        backButton.style.display = chatContainer?.style.display !== 'none' ? 'block' : 'none';
+        backButton.style.display = chatContainer && !chatContainer.classList.contains('hidden') ? 'block' : 'none';
     }
 });
 

--- a/public/styles.css
+++ b/public/styles.css
@@ -402,8 +402,27 @@ body {
     display: none;
   }
 
+  .chat-container {
+    transform: translateX(100%);
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
+    transition: transform 0.3s ease, opacity 0.3s ease;
+  }
+
   .chat-container.hidden {
-    display: none;
+    display: flex;
+    transform: translateX(100%);
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
+  }
+
+  .chat-container:not(.hidden) {
+    transform: translateX(0);
+    opacity: 1;
+    visibility: visible;
+    pointer-events: auto;
   }
 
   #backToChats {
@@ -913,11 +932,18 @@ body {
     width: 100%;
     height: 100%;
     z-index: 900;
-    display: none;
+    transform: translateX(100%);
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
+    transition: transform 0.3s ease, opacity 0.3s ease;
   }
 
   .chat-container:not(.hidden) {
-    display: flex;
+    transform: translateX(0);
+    opacity: 1;
+    visibility: visible;
+    pointer-events: auto;
   }
 
   .back-button {


### PR DESCRIPTION
## Summary
- animate chat container when entering or leaving a chat
- rely on CSS transitions instead of display toggling

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68516dce017c832dacd96915bef2f6ed