### PR TITLE
Ensure chat list is shown after username update

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -602,6 +602,7 @@ async function updateUserData(user, username, isNewUser, signOutOnConflict = fal
         if (!signOutOnConflict && !isNewUser) {
             showToast(getTranslation('usernameUpdated', getUserLanguage()));
         }
+        currentListType = 'individual';
         showMainScreen();
         updateUserInfo({ ...user, username });
         setupRealtimeChats(chatList, 'individual');
@@ -609,6 +610,7 @@ async function updateUserData(user, username, isNewUser, signOutOnConflict = fal
         console.error('Error al actualizar datos del usuario:', error);
         if (error.code === 'permission-denied') {
             // Si es un error de permisos pero el usuario está autenticado, continuar
+            currentListType = 'individual';
             showMainScreen();
             updateUserInfo({...user, username});
             setupRealtimeChats(chatList, 'individual');


### PR DESCRIPTION
## Summary
- keep the individual chat list active after changing username

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685508824c78832d9c7226e2afbd6436