### PR TITLE
Fix login inputs blocked by loading screen

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -892,12 +892,23 @@ document.addEventListener('DOMContentLoaded', () => {
 
 
 // Funciones de UI mejoradas
+// Loading screen helpers con temporizador de seguridad
+let loadingTimeout;
 function showLoadingScreen() {
-    document.querySelector('.loading-screen').style.display = 'flex';
+    const screen = document.querySelector('.loading-screen');
+    if (!screen) return;
+    screen.style.display = 'flex';
+    clearTimeout(loadingTimeout);
+    loadingTimeout = setTimeout(() => {
+        screen.style.display = 'none';
+    }, 5000); // evita que la pantalla bloquee la interacción
 }
 
 function hideLoadingScreen() {
-    document.querySelector('.loading-screen').style.display = 'none';
+    const screen = document.querySelector('.loading-screen');
+    if (!screen) return;
+    screen.style.display = 'none';
+    clearTimeout(loadingTimeout);
 }
 
 // Función para ajustar el diseño en móvil


### PR DESCRIPTION
## Summary
- add a timeout when showing the loading screen
- clear timeout and hide the overlay safely

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68550b5d0f34832d83bd18475beedfd6