### PR TITLE
Fix login page overlay

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -2414,6 +2414,8 @@ window.addEventListener('load', () => {
         currentUser = JSON.parse(savedUser);
         showMainScreen();
     }
+    // Asegura que la pantalla de carga no bloquee la interfaz
+    setTimeout(hideLoadingScreen, 1000);
 });
 
 // Mejorar la función de cerrar sesión

--- a/public/styles.css
+++ b/public/styles.css
@@ -382,6 +382,7 @@ body {
   z-index: 2000;
   backdrop-filter: blur(6px);
   -webkit-backdrop-filter: blur(6px);
+  pointer-events: none;
 }
 
 /* ==========================================================================


### PR DESCRIPTION
## Summary
- hide loading overlay after page load
- allow clicks through the loading overlay

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68550c803a10832dae2c917d4d0aa140