### PR TITLE
Fix permission error when deleting group chat

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1105,6 +1105,19 @@ async function deleteChat(chatId) {
             return;
         }
 
+        // Cancelar escuchas si el chat a borrar está abierto
+        if (currentChat === chatId) {
+            if (unsubscribeMessagesFn) {
+                unsubscribeMessagesFn();
+                unsubscribeMessagesFn = null;
+            }
+            if (unsubscribeTypingStatus) {
+                unsubscribeTypingStatus();
+                unsubscribeTypingStatus = null;
+            }
+            currentChat = null;
+        }
+
         // Obtener referencia al chat
         const chatRef = doc(db, 'chats', chatId);
         const chatDoc = await getDoc(chatRef);


### PR DESCRIPTION
## Summary
- stop message and typing listeners before removing a chat

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685513988004832db3ad52facf015ace