### PR TITLE
Handle typing listener cleanup on chat deletion

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1108,15 +1108,17 @@ async function deleteChat(chatId) {
         }
 
         // Cancelar escuchas activas relacionadas con este chat
+        if (unsubscribeMessagesFn) {
+            unsubscribeMessagesFn();
+            unsubscribeMessagesFn = null;
+        }
+
+        if (unsubscribeTypingStatus) {
+            unsubscribeTypingStatus();
+            unsubscribeTypingStatus = null;
+        }
+
         if (currentChat === chatId) {
-            if (unsubscribeMessagesFn) {
-                unsubscribeMessagesFn();
-                unsubscribeMessagesFn = null;
-            }
-            if (unsubscribeTypingStatus) {
-                unsubscribeTypingStatus();
-                unsubscribeTypingStatus = null;
-            }
             deletedChatIds.add(chatId);
             if (pendingChatId === chatId) {
                 pendingChatId = null;
@@ -1972,8 +1974,17 @@ unsubscribeMessagesFn = onSnapshot(newMessagesQuery, (snapshot) => {
         } else {
             hideTypingIndicator();
         }
-    }, (error) => {
-        console.error('Error en la suscripción de typingStatus:', error);
+    }, async (error) => {
+        console.warn('Error en la suscripción de typingStatus:', error);
+        try {
+            const chatExists = (await getDoc(doc(db, 'chats', chatId))).exists();
+            if (!chatExists) {
+                console.warn('El chat ya no existe, se ignora el listener de typingStatus');
+                return;
+            }
+        } catch (err) {
+            console.warn('Error comprobando existencia de chat:', err);
+        }
     });
 
     snapshot.docChanges().forEach(async change => {


### PR DESCRIPTION
## Summary
- stop `typingStatus` subscriptions when deleting a chat
- warn on `typingStatus` listener errors and ignore if parent chat is gone

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6855180dc45c832da78746db7c8f8901