### PR TITLE
Fix message order across senders

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -2062,14 +2062,14 @@ async function loadInitialMessages(chatId) {
             return timeA - timeB;
         });
 
-        // Mostrar mensajes
-        await Promise.all(messages.map(async (messageData) => {
+        // Mostrar mensajes de forma secuencial para mantener el orden
+        for (const messageData of messages) {
             if (messageData.type === 'system') {
                 displaySystemMessage(messageData);
             } else {
                 await displayMessage(messageData);
             }
-        }));
+        }
 
         messagesList.scrollTop = messagesList.scrollHeight;
         
@@ -2122,7 +2122,7 @@ async function loadMoreMessages(chatId) {
         const scrollTop = messagesList.scrollTop;
 
         // Mostrar mensajes en orden cronológico al inicio de la lista
-        messages.reverse().forEach(async messageData => {
+        for (const messageData of messages.reverse()) {
             const messageElement = document.createElement('div');
             if (messageData.type === 'system') {
                 await displaySystemMessage(messageData, messageElement);
@@ -2130,7 +2130,7 @@ async function loadMoreMessages(chatId) {
                 await displayMessage(messageData, messageElement);
             }
             messagesList.insertBefore(messageElement, messagesList.firstChild);
-        });
+        }
 
         // Mantener la posición del scroll
         messagesList.scrollTop = messagesList.scrollHeight - scrollHeight + scrollTop;


### PR DESCRIPTION
## Summary
- ensure message list loads sequentially so message order doesn't depend on sender
- process older messages sequentially as well

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685640f8db70832d83dd2071b8fb7885