### PR TITLE
Improve message ordering and caching

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -245,10 +245,12 @@ window.addEventListener('languageChanged', refreshSpeakButtons);
 
 // Variables para paginación
 const MESSAGES_PER_BATCH = 20; // Número de mensajes a cargar por lote
+const MAX_DISPLAYED_MESSAGES = 50; // Máximo de mensajes a renderizar al abrir un chat
 let isLoadingMore = false;
 let allMessagesLoaded = false;
 let lastVisibleMessage = null;
 let lastProcessedMessageId = null; // Variable para evitar duplicados
+let chatMessagesCache = state.messagesCache; // Persistir mensajes en memoria por chat
 
 // Enviar notificaciones push a los participantes de un chat
 // Esta función quedó obsoleta ya que las notificaciones se manejan
@@ -1872,7 +1874,7 @@ async function openChat(chatId) {
         // Limpiar mensajes anteriores
         if (messagesList) {
             messagesList.innerHTML = '';
-            
+
             // Añadir el loader al inicio de la lista
             const loaderDiv = document.createElement('div');
             loaderDiv.id = 'messages-loader';
@@ -1895,11 +1897,11 @@ async function openChat(chatId) {
             const style = document.createElement('style');
                 style.id = 'loader-styles';
             style.textContent = `
-                    .messages-loader {
-                        text-align: center;
-                    padding: 10px;
-                    }
-                    .loader-spinner {
+                      .messages-loader {
+                          text-align: center;
+                      padding: 10px;
+                      }
+                      .loader-spinner {
                         width: 20px;
                         height: 20px;
                         border: 2px solid #f3f3f3;
@@ -1914,6 +1916,26 @@ async function openChat(chatId) {
                 }
             `;
             document.head.appendChild(style);
+            }
+
+            // 👉 Mostrar mensajes desde caché si existen
+            const cached = chatMessagesCache[chatId];
+            if (cached && Array.isArray(cached.messages)) {
+                lastVisibleMessage = cached.lastVisibleMessage;
+                allMessagesLoaded = cached.allMessagesLoaded;
+                const start = Math.max(0, cached.messages.length - MAX_DISPLAYED_MESSAGES);
+                const messagesToShow = cached.messages.slice(start);
+                cached.displayOffset = start;
+                for (const messageData of messagesToShow) {
+                    if (messageData.type === 'system') {
+                        await displaySystemMessage(messageData);
+                    } else {
+                        await displayMessage(messageData);
+                    }
+                }
+                messagesList.scrollTop = messagesList.scrollHeight;
+                chatMessagesCache[chatId] = cached;
+                initialLoadComplete = true;
             }
         }
         
@@ -2010,6 +2032,9 @@ unsubscribeMessagesFn = onSnapshot(newMessagesQuery, (snapshot) => {
             if (messagesList) {
                 messagesList.scrollTop = messagesList.scrollHeight;
             }
+            const cache = chatMessagesCache[chatId] || { messages: [] };
+            cache.messages.push(messageData);
+            chatMessagesCache[chatId] = cache;
             markChatAsRead(chatId);
         }
     });
@@ -2049,7 +2074,7 @@ async function loadInitialMessages(chatId) {
         }));
 
         lastVisibleMessage = snapshot.docs[snapshot.docs.length - 1];
-        
+
         // Si hay mensajes, guardar el ID del último para evitar duplicados
         if (messages.length > 0) {
             lastProcessedMessageId = messages[0].id; // Guardamos el ID del mensaje más reciente
@@ -2062,8 +2087,16 @@ async function loadInitialMessages(chatId) {
             return timeA - timeB;
         });
 
-        // Mostrar mensajes de forma secuencial para mantener el orden
-        for (const messageData of messages) {
+        const cache = chatMessagesCache[chatId] || { messages: [] };
+        const existingIds = new Set(cache.messages.map(m => m.id));
+        const newMessages = messages.filter(m => !existingIds.has(m.id));
+        cache.messages = [...cache.messages, ...newMessages];
+        cache.lastVisibleMessage = lastVisibleMessage;
+        cache.allMessagesLoaded = false;
+        chatMessagesCache[chatId] = cache;
+
+        // Mostrar solo los mensajes nuevos en orden
+        for (const messageData of newMessages) {
             if (messageData.type === 'system') {
                 displaySystemMessage(messageData);
             } else {
@@ -2072,7 +2105,7 @@ async function loadInitialMessages(chatId) {
         }
 
         messagesList.scrollTop = messagesList.scrollHeight;
-        
+
         // Marcar la carga inicial como completa después de mostrar los mensajes
         initialLoadComplete = true;
         console.log('✅ Carga inicial completada, último mensaje procesado:', lastProcessedMessageId);
@@ -2088,8 +2121,40 @@ async function loadInitialMessages(chatId) {
 async function loadMoreMessages(chatId) {
     if (isLoadingMore || allMessagesLoaded) return;
 
-    isLoadingMore = true;
+    const cache = chatMessagesCache[chatId];
     const loaderDiv = document.getElementById('messages-loader');
+
+    // Si hay mensajes en caché que aún no se han mostrado, cargarlos primero
+    if (cache && typeof cache.displayOffset === 'number' && cache.displayOffset > 0) {
+        isLoadingMore = true;
+        if (loaderDiv) loaderDiv.style.display = 'block';
+
+        const start = Math.max(0, cache.displayOffset - MESSAGES_PER_BATCH);
+        const cachedMessages = cache.messages.slice(start, cache.displayOffset);
+        cache.displayOffset = start;
+        chatMessagesCache[chatId] = cache;
+
+        const scrollHeight = messagesList.scrollHeight;
+        const scrollTop = messagesList.scrollTop;
+
+        for (const messageData of cachedMessages.reverse()) {
+            const messageElement = document.createElement('div');
+            if (messageData.type === 'system') {
+                await displaySystemMessage(messageData, messageElement);
+            } else {
+                await displayMessage(messageData, messageElement);
+            }
+            messagesList.insertBefore(messageElement, messagesList.firstChild);
+        }
+
+        messagesList.scrollTop = messagesList.scrollHeight - scrollHeight + scrollTop;
+
+        isLoadingMore = false;
+        if (loaderDiv) loaderDiv.style.display = 'none';
+        return;
+    }
+
+    isLoadingMore = true;
     if (loaderDiv) loaderDiv.style.display = 'block';
 
     try {
@@ -2121,8 +2186,19 @@ async function loadMoreMessages(chatId) {
         const scrollHeight = messagesList.scrollHeight;
         const scrollTop = messagesList.scrollTop;
 
+        const cache = chatMessagesCache[chatId] || { messages: [] };
+        const existingIds = new Set(cache.messages.map(m => m.id));
+        const newMessages = [];
+        for (const m of messages) {
+            if (!existingIds.has(m.id)) newMessages.push(m);
+        }
+        cache.messages = [...newMessages.reverse(), ...cache.messages];
+        cache.lastVisibleMessage = lastVisibleMessage;
+        cache.displayOffset = (cache.displayOffset || 0) + newMessages.length;
+        chatMessagesCache[chatId] = cache;
+
         // Mostrar mensajes en orden cronológico al inicio de la lista
-        for (const messageData of messages.reverse()) {
+        for (const messageData of newMessages.reverse()) {
             const messageElement = document.createElement('div');
             if (messageData.type === 'system') {
                 await displaySystemMessage(messageData, messageElement);

--- a/public/modules/state.js
+++ b/public/modules/state.js
@@ -18,6 +18,7 @@ export const state = {
     isLoadingMore: false,
     allMessagesLoaded: false,
     lastVisibleMessage: null,
+    messagesCache: {},
 };
 
 let currentUser = null;


### PR DESCRIPTION
## Summary
- add a cache for messages in state
- store chat messages in memory to avoid reloading them when reopening a chat
- load cached messages first and only fetch new data
- update message loading functions to fill cache
- only render a subset of cached messages when opening a chat for faster load
- load extra cached messages before querying Firestore

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68564b9ecba4832daeb956e3598b6d64