### PR TITLE
Improve message rendering performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,10 @@ pantalla de inicio para poder solicitar el permiso y recibirlas correctamente.
 
 Las contribuciones son bienvenidas. Por favor, abre un issue primero para discutir los cambios que te gustaría hacer.
 
+## Rendimiento
+
+La aplicación carga los mensajes de cada chat en lotes de 20 y mantiene un máximo de 50 elementos en pantalla para evitar sobrecargar el DOM. Se recomienda habilitar la **persistencia offline** de Firestore para que los mensajes ya descargados se lean desde el caché local cuando sea posible. Si la app muestra advertencias de índices al consultar mensajes, crea los índices definidos en `firestore.indexes.json` desde la consola de Firebase.
+
 ### Cambios recientes
 
 - Se eliminó la duplicación de notificaciones push y se mejoró el manejo del estado de escritura para evitar parpadeos en la lista de chats.

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,0 +1,13 @@
+{
+  "indexes": [
+    {
+      "collectionGroup": "messages",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "senderId", "order": "ASCENDING" },
+        { "fieldPath": "timestamp", "order": "ASCENDING" }
+      ]
+    }
+  ],
+  "fieldOverrides": []
+}

--- a/public/app.js
+++ b/public/app.js
@@ -253,6 +253,13 @@ let lastVisibleMessage = null;
 let lastProcessedMessageId = null; // Variable para evitar duplicados
 let chatMessagesCache = state.messagesCache; // Persistir mensajes en memoria por chat
 
+function trimMessagesList() {
+    if (!messagesList) return;
+    while (messagesList.childElementCount > MAX_DISPLAYED_MESSAGES) {
+        messagesList.removeChild(messagesList.firstElementChild);
+    }
+}
+
 // Enviar notificaciones push a los participantes de un chat
 // Esta función quedó obsoleta ya que las notificaciones se manejan
 // mediante Cloud Functions al crear cada mensaje. Se mantiene por si se
@@ -1797,6 +1804,7 @@ async function displayMessage(messageData) {
 
         messagesList.appendChild(messageElement);
         addSwipeActions(messageElement);
+        trimMessagesList();
         messagesList.scrollTop = messagesList.scrollHeight;
     } else {
         console.error('❌ Lista de mensajes no encontrada');
@@ -2336,6 +2344,7 @@ function displaySystemMessage(messageData) {
     `;
 
     messagesList.appendChild(messageElement);
+    trimMessagesList();
     messagesList.scrollTop = messagesList.scrollHeight;
 }
 


### PR DESCRIPTION
## Summary
- limit DOM nodes when displaying messages
- update README with offline persistence and index info
- add Firestore indexes configuration

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685653eeca30832d8fde7dccc1215f67