### PR TITLE
Fix message order with concurrent rendering

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1904,15 +1904,18 @@ async function openChat(chatId) {
                 const messagesToShow = cached.messages.slice(start);
                 cached.displayOffset = start;
                 const fragment = document.createDocumentFragment();
-                await Promise.all(messagesToShow.map(async messageData => {
+                const elements = await Promise.all(messagesToShow.map(async messageData => {
                     const el = document.createElement('div');
                     if (messageData.type === 'system') {
                         displaySystemMessage(messageData, el);
                     } else {
                         await displayMessage(messageData, { ...context, container: el });
                     }
-                    fragment.appendChild(el);
+                    return el;
                 }));
+                for (const el of elements) {
+                    fragment.appendChild(el);
+                }
                 messagesList.appendChild(fragment);
                 trimMessagesList();
                 messagesList.scrollTop = messagesList.scrollHeight;
@@ -2083,17 +2086,18 @@ async function loadInitialMessages(chatId, context) {
         const fragment = document.createDocumentFragment();
         const wasAtBottom = messagesList.scrollHeight - messagesList.scrollTop <= messagesList.clientHeight + 1;
 
-        await Promise.all(newMessages.map(async messageData => {
+        const elements = await Promise.all(newMessages.map(async messageData => {
+            const el = document.createElement('div');
             if (messageData.type === 'system') {
-                const el = document.createElement('div');
                 displaySystemMessage(messageData, el);
-                fragment.appendChild(el);
             } else {
-                const el = document.createElement('div');
                 await displayMessage(messageData, { ...context, container: el });
-                fragment.appendChild(el);
             }
+            return el;
         }));
+        for (const el of elements) {
+            fragment.appendChild(el);
+        }
 
         messagesList.appendChild(fragment);
         trimMessagesList();


### PR DESCRIPTION
## Summary
- collect message DOM elements in arrays when rendering multiple messages concurrently
- append the elements in order to maintain chronological order

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685668e71420832d8b5946862a584838