### PR TITLE
Fix push notifications for background mode

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -79,6 +79,10 @@ exports.sendMessageNotification = functions.firestore
                 try {
                     const notificationMessage = {
                         token,
+                        notification: {
+                            title: senderName,
+                            body: message.text
+                        },
                         data: {
                             title: senderName,
                             body: message.text,

--- a/public/firebase-messaging-sw.js
+++ b/public/firebase-messaging-sw.js
@@ -21,10 +21,14 @@ console.log('✅ Firebase Messaging inicializado en Service Worker');
 const shownMessages = new Set();
 
 async function showNotification(payload) {
-  const notificationTitle =
-    payload.notification?.title || payload.data?.title || 'TraduChat';
+  if (payload.notification) {
+    // Si FCM ya maneja la notificación, no duplicar
+    return;
+  }
+
+  const notificationTitle = payload.data?.title || 'TraduChat';
   const notificationOptions = {
-    body: payload.notification?.body || payload.data?.body || '',
+    body: payload.data?.body || '',
     icon: '/images/icon-192.png',
     badge: '/images/icon-72x72.png',
     vibrate: [200, 100, 200],

--- a/server.js
+++ b/server.js
@@ -62,6 +62,10 @@ app.post(['/api/send-notification', '/send-notification'], async (req, res) => {
                     body: JSON.stringify({
                         message: {
                             token,
+                            notification: {
+                                title,
+                                body
+                            },
                             data: {
                                 title,
                                 body,
@@ -88,6 +92,10 @@ app.post(['/api/send-notification', '/send-notification'], async (req, res) => {
                 },
                 body: JSON.stringify({
                     to: token,
+                    notification: {
+                        title,
+                        body
+                    },
                     data: {
                         title,
                         body,


### PR DESCRIPTION
## Summary
- send `notification` payload along with data from server and functions
- avoid showing duplicate notifications in service worker

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6856a21bc734832da53deb386e450dd9