### PR TITLE
Ensure group creation push notifications display in background

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -170,6 +170,10 @@ exports.sendGroupCreationNotification = functions.firestore
 
             const multicastMessage = {
                 tokens,
+                notification: {
+                    title: name,
+                    body: `${creatorName} ha creado este grupo`
+                },
                 data: {
                     title: name,
                     body: `${creatorName} ha creado este grupo`,


### PR DESCRIPTION
## Summary
- send proper notification payload on group creation

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6856a59bc530832da2f2d13aba74a62a