### PR TITLE
Fix FCM notifications and SW duplicate handling

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -88,12 +88,12 @@ exports.sendMessageNotification = functions.firestore
                             body: message.text,
                             chatId,
                             messageId: context.params.messageId,
-                            type: 'new_message',
+                            type: 'message',
                             chatType
                         },
                         webpush: {
                             fcmOptions: {
-                                link: chatType === 'group' ? '/?view=groups' : '/'
+                                link: `/?view=chats&chatId=${chatId}`
                             }
                         }
                     };

--- a/public/firebase-messaging-sw.js
+++ b/public/firebase-messaging-sw.js
@@ -21,14 +21,11 @@ console.log('✅ Firebase Messaging inicializado en Service Worker');
 const shownMessages = new Set();
 
 async function showNotification(payload) {
-  if (payload.notification) {
-    // Si FCM ya maneja la notificación, no duplicar
-    return;
-  }
-
-  const notificationTitle = payload.data?.title || 'TraduChat';
+  const notificationTitle = payload.data?.title ||
+    payload.notification?.title ||
+    'TraduChat';
   const notificationOptions = {
-    body: payload.data?.body || '',
+    body: payload.data?.body || payload.notification?.body || '',
     icon: '/images/icon-192.png',
     badge: '/images/icon-72x72.png',
     vibrate: [200, 100, 200],
@@ -38,15 +35,20 @@ async function showNotification(payload) {
 
   const msgId = notificationOptions.tag;
 
-  if (!shownMessages.has(msgId)) {
-    shownMessages.add(msgId);
-    const existing = await self.registration.getNotifications({ tag: msgId });
-    if (existing.length === 0) {
-      await self.registration.showNotification(
-        notificationTitle,
-        notificationOptions
-      );
+  // Evitar duplicados solo si FCM ya incluyó la notificación
+  if (payload.notification) {
+    if (shownMessages.has(msgId)) {
+      return;
     }
+    shownMessages.add(msgId);
+  }
+
+  const existing = await self.registration.getNotifications({ tag: msgId });
+  if (existing.length === 0) {
+    await self.registration.showNotification(
+      notificationTitle,
+      notificationOptions
+    );
   }
 }
 


### PR DESCRIPTION
## Summary
- ensure sendMessageNotification includes both `notification` and `data` with proper web link
- tweak service worker to always display notifications and deduplicate only when FCM added a `notification` payload

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6856aa292050832da387a74788a86b38