### PR TITLE
Fix Safari push

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -79,10 +79,6 @@ exports.sendMessageNotification = functions.firestore
                 try {
                     const notificationMessage = {
                         token,
-                        notification: {
-                            title: senderName,
-                            body: message.text
-                        },
                         data: {
                             title: senderName,
                             body: message.text,
@@ -170,10 +166,6 @@ exports.sendGroupCreationNotification = functions.firestore
 
             const multicastMessage = {
                 tokens,
-                notification: {
-                    title: name,
-                    body: `${creatorName} ha creado este grupo`
-                },
                 data: {
                     title: name,
                     body: `${creatorName} ha creado este grupo`,


### PR DESCRIPTION
## Summary
- send data-only push messages in Cloud Functions to avoid reliance on FCM auto notifications

## Testing
- `npm test` *(fails: no tests specified)*

------
https://chatgpt.com/codex/tasks/task_e_6856af481710832dadd8fe27ee6e9a14