### PR TITLE
Fix notification init order

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -78,12 +78,12 @@ startAuthListener(async (userData) => {
         handleViewFromUrl();
         updateUserInfo(userData);
         setupRealtimeChats(chatList, 'individual');
+        initializeNotifications(); // Mover antes de abrir el chat
         if (pendingChatId && !chatFromUrlHandled) {
             openChat(pendingChatId);
             chatFromUrlHandled = true;
             pendingChatId = null;
         }
-        initializeNotifications(); // Aquí está bien colocada
     } else {
         console.log('No hay usuario autenticado');
         currentUser = null;


### PR DESCRIPTION
## Summary
- ensure initializeNotifications runs before any openChat call to register the service worker

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6857cc29750c832d90fde080bd8c8c3f