### PR TITLE
Fix notification init order across auth listeners

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -854,6 +854,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 if (languageSelectMain) languageSelectMain.value = lang;
 
                 showMainScreen();
+                initializeNotifications();
                 if (pendingChatId && !chatFromUrlHandled && auth.currentUser) {
                     openChat(pendingChatId);
                     chatFromUrlHandled = true;


### PR DESCRIPTION
## Summary
- initialize notifications earlier in the secondary auth listener

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6857d2e5c80c832daffed6036d38d10a