### PR TITLE
Fix FCM payloads for iOS push

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -79,6 +79,10 @@ exports.sendMessageNotification = functions.firestore
                 try {
                     const notificationMessage = {
                         token,
+                        notification: {
+                            title: senderName,
+                            body: message.text
+                        },
                         data: {
                             title: senderName,
                             body: message.text,
@@ -166,6 +170,10 @@ exports.sendGroupCreationNotification = functions.firestore
 
             const multicastMessage = {
                 tokens,
+                notification: {
+                    title: name,
+                    body: `${creatorName} ha creado este grupo`
+                },
                 data: {
                     title: name,
                     body: `${creatorName} ha creado este grupo`,


### PR DESCRIPTION
## Summary
- add explicit notification field in FCM functions to allow iOS delivery

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68580eb79e9c832da4568f817e20bc33