### PR TITLE
Disable auto FCM notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,3 +96,5 @@ La aplicación carga los mensajes de cada chat en lotes de 20 y mantiene un máx
 
 - Se eliminó la duplicación de notificaciones push y se mejoró el manejo del estado de escritura para evitar parpadeos en la lista de chats.
 - Se ajustó el *service worker* para mostrar correctamente las notificaciones cuando la aplicación está en segundo plano.
+- Se desactivó el envío manual de notificaciones desde el cliente para evitar duplicados cuando funcionan las Cloud Functions.
+- Las Cloud Functions vuelven a enviar las notificaciones como mensajes solo de datos para evitar duplicados en la web.

--- a/functions/index.js
+++ b/functions/index.js
@@ -79,10 +79,6 @@ exports.sendMessageNotification = functions.firestore
                 try {
                     const notificationMessage = {
                         token,
-                        notification: {
-                            title: senderName,
-                            body: message.text
-                        },
                         data: {
                             title: senderName,
                             body: message.text,
@@ -170,10 +166,6 @@ exports.sendGroupCreationNotification = functions.firestore
 
             const multicastMessage = {
                 tokens,
-                notification: {
-                    title: name,
-                    body: `${creatorName} ha creado este grupo`
-                },
                 data: {
                     title: name,
                     body: `${creatorName} ha creado este grupo`,

--- a/public/app.js
+++ b/public/app.js
@@ -180,7 +180,9 @@ pendingChatId = initialParams.get('chatId');
 // Se vuelve a habilitar para asegurar envíos desde el cliente cuando
 // las Cloud Functions no estén disponibles. Las notificaciones se
 // deduplican por `messageId` en el Service Worker.
-const manualPushNotifications = true;
+// Desactiva el envío de notificaciones desde el cliente para evitar
+// duplicados cuando las Cloud Functions estén activas
+const manualPushNotifications = false;
 
 
 // Variables para grabación de audio

--- a/server.js
+++ b/server.js
@@ -62,10 +62,6 @@ app.post(['/api/send-notification', '/send-notification'], async (req, res) => {
                     body: JSON.stringify({
                         message: {
                             token,
-                            notification: {
-                                title,
-                                body
-                            },
                             data: {
                                 title,
                                 body,
@@ -92,13 +88,10 @@ app.post(['/api/send-notification', '/send-notification'], async (req, res) => {
                 },
                 body: JSON.stringify({
                     to: token,
-                    notification: {
-                        title,
-                        body
-                    },
                     data: {
                         title,
                         body,
+                        icon: '/images/icon-192.png',
                         ...extraData
                     }
                 })


### PR DESCRIPTION
## Summary
- revert FCM functions to send data-only payloads to avoid duplicate push messages
- document that Cloud Functions now send notifications as data only

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6858188b3b68832dabe72441ec69e336